### PR TITLE
feat: Kubernetes Helm Chart (#50)

### DIFF
--- a/charts/tfdrift-falco/Chart.yaml
+++ b/charts/tfdrift-falco/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: tfdrift-falco
+description: Real-time, multi-cloud Terraform drift detection with Falco integration
+type: application
+version: 0.1.0
+appVersion: "0.8.0"
+keywords:
+  - terraform
+  - drift-detection
+  - falco
+  - security
+  - multi-cloud
+  - aws
+  - gcp
+  - azure
+home: https://github.com/higakikeita/tfdrift-falco
+sources:
+  - https://github.com/higakikeita/tfdrift-falco
+maintainers:
+  - name: Keita Higaki
+    url: https://github.com/higakikeita

--- a/charts/tfdrift-falco/templates/_helpers.tpl
+++ b/charts/tfdrift-falco/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tfdrift-falco.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "tfdrift-falco.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tfdrift-falco.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tfdrift-falco.labels" -}}
+helm.sh/chart: {{ include "tfdrift-falco.chart" . }}
+{{ include "tfdrift-falco.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tfdrift-falco.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tfdrift-falco.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tfdrift-falco.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tfdrift-falco.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/tfdrift-falco/templates/configmap.yaml
+++ b/charts/tfdrift-falco/templates/configmap.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tfdrift-falco.fullname" . }}-config
+  labels:
+    {{- include "tfdrift-falco.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    providers:
+      aws:
+        enabled: {{ .Values.config.providers.aws.enabled }}
+        regions:
+          {{- toYaml .Values.config.providers.aws.regions | nindent 10 }}
+        state:
+          backend: {{ .Values.config.providers.aws.state.backend | quote }}
+          {{- if .Values.config.providers.aws.state.s3Bucket }}
+          s3_bucket: {{ .Values.config.providers.aws.state.s3Bucket | quote }}
+          {{- end }}
+          {{- if .Values.config.providers.aws.state.s3Key }}
+          s3_key: {{ .Values.config.providers.aws.state.s3Key | quote }}
+          {{- end }}
+          {{- if .Values.config.providers.aws.state.s3Region }}
+          s3_region: {{ .Values.config.providers.aws.state.s3Region | quote }}
+          {{- end }}
+      gcp:
+        enabled: {{ .Values.config.providers.gcp.enabled }}
+        {{- if .Values.config.providers.gcp.projects }}
+        projects:
+          {{- toYaml .Values.config.providers.gcp.projects | nindent 10 }}
+        {{- end }}
+        state:
+          backend: {{ .Values.config.providers.gcp.state.backend | quote }}
+          {{- if .Values.config.providers.gcp.state.gcsBucket }}
+          gcs_bucket: {{ .Values.config.providers.gcp.state.gcsBucket | quote }}
+          {{- end }}
+          {{- if .Values.config.providers.gcp.state.gcsPrefix }}
+          gcs_prefix: {{ .Values.config.providers.gcp.state.gcsPrefix | quote }}
+          {{- end }}
+      azure:
+        enabled: {{ .Values.config.providers.azure.enabled }}
+        {{- if .Values.config.providers.azure.subscriptions }}
+        subscriptions:
+          {{- toYaml .Values.config.providers.azure.subscriptions | nindent 10 }}
+        {{- end }}
+        state:
+          backend: {{ .Values.config.providers.azure.state.backend | quote }}
+          {{- if .Values.config.providers.azure.state.resourceGroup }}
+          azure_resource_group: {{ .Values.config.providers.azure.state.resourceGroup | quote }}
+          {{- end }}
+          {{- if .Values.config.providers.azure.state.storageAccount }}
+          azure_storage_account: {{ .Values.config.providers.azure.state.storageAccount | quote }}
+          {{- end }}
+          {{- if .Values.config.providers.azure.state.containerName }}
+          azure_container_name: {{ .Values.config.providers.azure.state.containerName | quote }}
+          {{- end }}
+          {{- if .Values.config.providers.azure.state.key }}
+          azure_key: {{ .Values.config.providers.azure.state.key | quote }}
+          {{- end }}
+    falco:
+      enabled: true
+      hostname: {{ .Values.config.falco.hostname | quote }}
+      port: {{ .Values.config.falco.port }}
+    api:
+      auth:
+        enabled: {{ .Values.config.auth.enabled }}
+        jwt_issuer: {{ .Values.config.auth.jwtIssuer | quote }}
+        jwt_expiry: {{ .Values.config.auth.jwtExpiry | quote }}
+      rate_limit:
+        enabled: {{ .Values.config.rateLimit.enabled }}
+        requests_per_minute: {{ .Values.config.rateLimit.requestsPerMinute }}
+        burst_size: {{ .Values.config.rateLimit.burstSize }}
+    logging:
+      level: {{ .Values.config.logLevel | quote }}
+      format: {{ .Values.config.logFormat | quote }}

--- a/charts/tfdrift-falco/templates/deployment.yaml
+++ b/charts/tfdrift-falco/templates/deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tfdrift-falco.fullname" . }}
+  labels:
+    {{- include "tfdrift-falco.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "tfdrift-falco.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "tfdrift-falco.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "tfdrift-falco.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--server"
+            - "--port"
+            - "{{ .Values.config.port }}"
+            - "--config"
+            - "/etc/tfdrift-falco/config.yaml"
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          env:
+            {{- if or .Values.config.auth.jwtSecret .Values.existingSecret }}
+            - name: TFDRIFT_API_AUTH_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret | default (printf "%s-secret" (include "tfdrift-falco.fullname" .)) }}
+                  key: jwt-secret
+            {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/tfdrift-falco
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "tfdrift-falco.fullname" . }}-config
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/tfdrift-falco/templates/hpa.yaml
+++ b/charts/tfdrift-falco/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "tfdrift-falco.fullname" . }}
+  labels:
+    {{- include "tfdrift-falco.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "tfdrift-falco.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/tfdrift-falco/templates/ingress.yaml
+++ b/charts/tfdrift-falco/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tfdrift-falco.fullname" . }}
+  labels:
+    {{- include "tfdrift-falco.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "tfdrift-falco.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/tfdrift-falco/templates/networkpolicy.yaml
+++ b/charts/tfdrift-falco/templates/networkpolicy.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "tfdrift-falco.fullname" . }}
+  labels:
+    {{- include "tfdrift-falco.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "tfdrift-falco.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow HTTP traffic from within the cluster
+    - ports:
+        - port: {{ .Values.config.port }}
+          protocol: TCP
+      {{- if .Values.networkPolicy.ingressNamespaces }}
+      from:
+        {{- range .Values.networkPolicy.ingressNamespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . }}
+        {{- end }}
+      {{- end }}
+  egress:
+    # Allow DNS resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow Falco gRPC
+    - ports:
+        - port: {{ .Values.config.falco.port }}
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.falcoNamespace }}
+    # Allow HTTPS (cloud API access)
+    - ports:
+        - port: 443
+          protocol: TCP
+{{- end }}

--- a/charts/tfdrift-falco/templates/secret.yaml
+++ b/charts/tfdrift-falco/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if and (not .Values.existingSecret) .Values.config.auth.jwtSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tfdrift-falco.fullname" . }}-secret
+  labels:
+    {{- include "tfdrift-falco.labels" . | nindent 4 }}
+type: Opaque
+data:
+  jwt-secret: {{ .Values.config.auth.jwtSecret | b64enc | quote }}
+{{- end }}

--- a/charts/tfdrift-falco/templates/service.yaml
+++ b/charts/tfdrift-falco/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tfdrift-falco.fullname" . }}
+  labels:
+    {{- include "tfdrift-falco.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "tfdrift-falco.selectorLabels" . | nindent 4 }}

--- a/charts/tfdrift-falco/templates/serviceaccount.yaml
+++ b/charts/tfdrift-falco/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tfdrift-falco.serviceAccountName" . }}
+  labels:
+    {{- include "tfdrift-falco.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tfdrift-falco/templates/servicemonitor.yaml
+++ b/charts/tfdrift-falco/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "tfdrift-falco.fullname" . }}
+  labels:
+    {{- include "tfdrift-falco.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "tfdrift-falco.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/charts/tfdrift-falco/values.yaml
+++ b/charts/tfdrift-falco/values.yaml
@@ -1,0 +1,201 @@
+# Default values for tfdrift-falco
+# Override these values for your environment
+
+# -- Number of replicas
+replicaCount: 1
+
+image:
+  # -- Container image repository
+  repository: ghcr.io/higakikeita/tfdrift-falco
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Image tag (defaults to Chart appVersion)
+  tag: ""
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+# -- Override the chart name
+nameOverride: ""
+# -- Override the full release name
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: true
+  # -- Annotations for the ServiceAccount (e.g., for IRSA/Workload Identity)
+  annotations: {}
+  # -- ServiceAccount name (auto-generated if empty)
+  name: ""
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod security context
+podSecurityContext:
+  fsGroup: 1000
+
+# -- Container security context
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- API server port
+  port: 8080
+
+ingress:
+  # -- Enable ingress
+  enabled: false
+  # -- Ingress class name
+  className: ""
+  # -- Ingress annotations
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: tfdrift-falco.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- TLS configuration
+  tls: []
+  #  - secretName: tfdrift-falco-tls
+  #    hosts:
+  #      - tfdrift-falco.example.com
+
+# -- Resource requests and limits
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  # -- Enable HPA
+  enabled: false
+  # -- Minimum replicas
+  minReplicas: 1
+  # -- Maximum replicas
+  maxReplicas: 5
+  # -- Target CPU utilization percentage
+  targetCPUUtilizationPercentage: 80
+  # -- Target memory utilization percentage
+  targetMemoryUtilizationPercentage: 80
+
+# -- Node selector
+nodeSelector: {}
+
+# -- Tolerations
+tolerations: []
+
+# -- Affinity rules
+affinity: {}
+
+# TFDrift-Falco configuration
+config:
+  # -- API server port (must match service.port)
+  port: 8080
+
+  # -- Log level (debug, info, warning, error)
+  logLevel: info
+
+  # -- Log format (json, text)
+  logFormat: json
+
+  # Authentication settings
+  auth:
+    # -- Enable API authentication
+    enabled: true
+    # -- JWT signing secret (use existingSecret in production)
+    jwtSecret: ""
+    # -- JWT issuer
+    jwtIssuer: "tfdrift-falco"
+    # -- JWT token expiry
+    jwtExpiry: "24h"
+
+  # Rate limiting settings
+  rateLimit:
+    # -- Enable rate limiting
+    enabled: true
+    # -- Requests per minute per client
+    requestsPerMinute: 60
+    # -- Burst size
+    burstSize: 10
+
+  # Falco integration
+  falco:
+    # -- Falco gRPC hostname
+    hostname: "falco"
+    # -- Falco gRPC port
+    port: 5060
+
+  # Cloud providers
+  providers:
+    aws:
+      # -- Enable AWS provider
+      enabled: true
+      # -- AWS regions to monitor
+      regions:
+        - us-east-1
+      state:
+        # -- Terraform state backend (local, s3)
+        backend: "s3"
+        # -- S3 bucket for Terraform state
+        s3Bucket: ""
+        # -- S3 key for Terraform state
+        s3Key: ""
+        # -- S3 region for Terraform state
+        s3Region: "us-east-1"
+
+    gcp:
+      # -- Enable GCP provider
+      enabled: false
+      # -- GCP project IDs
+      projects: []
+      state:
+        backend: "gcs"
+        gcsBucket: ""
+        gcsPrefix: ""
+
+    azure:
+      # -- Enable Azure provider
+      enabled: false
+      # -- Azure subscription IDs
+      subscriptions: []
+      state:
+        backend: "azurerm"
+        resourceGroup: ""
+        storageAccount: ""
+        containerName: ""
+        key: ""
+
+# -- Existing secret for sensitive values (jwt_secret, api_keys)
+# Secret should contain: jwt-secret
+existingSecret: ""
+
+# Network policy
+networkPolicy:
+  # -- Enable network policy
+  enabled: false
+  # -- Allow ingress from these namespaces
+  ingressNamespaces: []
+  # -- Allow egress to Falco namespace
+  falcoNamespace: "falco"
+
+# ServiceMonitor for Prometheus
+serviceMonitor:
+  # -- Enable ServiceMonitor (requires Prometheus Operator)
+  enabled: false
+  # -- Scrape interval
+  interval: 30s
+  # -- Additional labels for the ServiceMonitor
+  labels: {}


### PR DESCRIPTION
## Summary
- Production-ready Helm Chart with Deployment, Service, ConfigMap, Secret, Ingress
- HPA for auto-scaling, NetworkPolicy for pod isolation, ServiceMonitor for Prometheus
- Configurable for all 3 cloud providers (AWS, GCP, Azure) + Falco + auth + rate limiting
- Security-hardened: non-root, read-only filesystem, dropped capabilities

Closes #50

## Test plan
- [ ] `helm template` renders without errors
- [ ] `helm lint` passes
- [ ] Review values.yaml documentation
- [ ] Verify ConfigMap generates valid config.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)