### PR TITLE
chore: Add CODEOWNERS, .editorconfig, and Dependabot (#60)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,66 @@
+# EditorConfig — https://editorconfig.org
+root = true
+
+# Default settings for all files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Go files — tabs per gofmt convention
+[*.go]
+indent_style = tab
+indent_size = 4
+
+# Makefiles require tabs
+[Makefile]
+indent_style = tab
+indent_size = 4
+
+[*.mk]
+indent_style = tab
+indent_size = 4
+
+# YAML files
+[*.{yml,yaml}]
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# TypeScript / JavaScript / JSX / TSX
+[*.{ts,tsx,js,jsx}]
+indent_size = 2
+
+# CSS / SCSS
+[*.{css,scss}]
+indent_size = 2
+
+# HTML
+[*.html]
+indent_size = 2
+
+# Markdown — trailing whitespace can be significant
+[*.md]
+trim_trailing_whitespace = false
+
+# Shell scripts
+[*.sh]
+indent_size = 2
+
+# Dockerfile
+[Dockerfile*]
+indent_size = 4
+
+# Helm templates
+[charts/**.yaml]
+indent_size = 2
+
+# Go module files
+[go.{mod,sum}]
+indent_style = tab
+indent_size = 4

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,40 @@
+# TFDrift-Falco Code Owners
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything
+* @higakikeita
+
+# Backend (Go)
+/pkg/ @higakikeita
+/cmd/ @higakikeita
+/go.mod @higakikeita
+/go.sum @higakikeita
+
+# Cloud provider integrations
+/pkg/falco/ @higakikeita
+/pkg/gcp/ @higakikeita
+/pkg/azure/ @higakikeita
+
+# API & middleware
+/pkg/api/ @higakikeita
+
+# Frontend (React/TypeScript)
+/ui/ @higakikeita
+
+# Infrastructure & deployment
+/charts/ @higakikeita
+/docker-compose*.yml @higakikeita
+/Dockerfile @higakikeita
+
+# CI/CD
+/.github/workflows/ @higakikeita
+
+# Documentation
+/docs/ @higakikeita
+/README.md @higakikeita
+/README.ja.md @higakikeita
+/CHANGELOG.md @higakikeita
+
+# Configuration & project governance
+/.github/CODEOWNERS @higakikeita
+/config.yaml.example @higakikeita

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+
+updates:
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # npm (frontend)
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+  # Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps"
+      include: "scope"


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` for automatic PR review routing across all major directories
- Add `.editorconfig` for editor-agnostic formatting (Go tabs, 2-space default for frontend/YAML/JSON)
- Add `.github/dependabot.yml` for automated dependency updates (Go modules weekly, npm weekly, GitHub Actions weekly, Docker monthly)

## Test plan
- [ ] Verify CODEOWNERS syntax is valid
- [ ] Verify .editorconfig settings match project conventions
- [ ] Verify Dependabot config targets correct directories

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)