### PR TITLE
docs: Add Architecture Decision Records (ADRs) (#59)

### DIFF
--- a/docs/adr/000-use-adrs.md
+++ b/docs/adr/000-use-adrs.md
@@ -1,0 +1,35 @@
+# ADR-000: Use Architecture Decision Records
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-22
+
+## Context
+
+As TFDrift-Falco grows in complexity (multi-cloud support, enterprise security features, Kubernetes deployment), architectural decisions are being made that have long-term consequences. Without a formal record, the reasoning behind decisions is lost, making it difficult for new contributors to understand design choices and for the team to revisit decisions when circumstances change.
+
+## Decision
+
+We will use Architecture Decision Records (ADRs) following the Michael Nygard format to document significant architectural decisions. ADRs will be stored in `docs/adr/` and numbered sequentially. Each ADR captures the context, decision, and consequences of a choice.
+
+## Consequences
+
+### Positive
+
+- Architectural decisions are documented with their rationale
+- New contributors can understand why things are built a certain way
+- Decisions can be revisited when the original context changes
+- Creates a decision log that serves as project history
+
+### Negative
+
+- Adds a small overhead to the development process for significant decisions
+- Requires discipline to write ADRs before or shortly after making decisions
+
+### Neutral
+
+- ADRs are immutable once accepted; new decisions create new ADRs rather than modifying old ones

--- a/docs/adr/001-event-driven-falco-grpc.md
+++ b/docs/adr/001-event-driven-falco-grpc.md
@@ -1,0 +1,49 @@
+# ADR-001: Event-Driven Architecture with Falco gRPC
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-22
+
+## Context
+
+TFDrift-Falco needs to detect infrastructure drift in real-time. The traditional approach is periodic polling — scanning Terraform state and comparing it against cloud resources on a schedule. However, polling introduces latency (minutes to hours between scans) and wastes resources scanning unchanged infrastructure.
+
+Falco is an open-source runtime security tool that can monitor cloud API audit logs (CloudTrail, GCP Audit Logs, Azure Activity Logs) via its plugin framework. It provides a gRPC output API that streams detected events in real-time.
+
+We needed to decide between:
+
+1. **Periodic polling** — Scheduled scans comparing Terraform state to cloud reality
+2. **Event-driven via Falco gRPC** — Subscribe to Falco's gRPC stream for real-time cloud API events
+3. **Direct cloud API integration** — Subscribe directly to CloudTrail/Pub/Sub/Event Grid
+
+## Decision
+
+We adopt an event-driven architecture using Falco's gRPC output API as the primary event source. TFDrift-Falco subscribes to Falco's gRPC stream (`pkg/falco/subscriber.go`) and processes events through provider-specific parsers (AWS, GCP, Azure) that map cloud API calls to Terraform resource types.
+
+The event pipeline is: Cloud API → Audit Logs → Falco Plugin → gRPC Stream → TFDrift-Falco Subscriber → Event Parser → Resource Mapper → Drift Detection Engine.
+
+## Consequences
+
+### Positive
+
+- Real-time drift detection (seconds, not minutes/hours)
+- Resource-efficient — only processes actual changes, not full infrastructure scans
+- Leverages Falco's mature plugin ecosystem for multi-cloud audit log parsing
+- Security context — Falco provides threat detection alongside drift detection
+- Extensible — new cloud providers can be added via Falco plugins
+
+### Negative
+
+- Dependency on Falco — requires Falco deployment alongside TFDrift-Falco
+- Complexity — gRPC connection management, reconnection logic, backpressure handling
+- Audit log delivery latency varies by provider (CloudTrail: 5-15 min via S3, GCP: 30s-5min via Pub/Sub)
+- Cannot detect drift that occurred before TFDrift-Falco started (no historical scan)
+
+### Neutral
+
+- Falco's plugin framework handles the complexity of parsing provider-specific audit log formats
+- gRPC provides efficient binary protocol with streaming support

--- a/docs/adr/002-in-memory-graph-store.md
+++ b/docs/adr/002-in-memory-graph-store.md
@@ -1,0 +1,48 @@
+# ADR-002: In-Memory Graph Store Over External Database
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-22
+
+## Context
+
+TFDrift-Falco builds a dependency graph of cloud resources, Terraform state, and drift relationships. This graph needs to support queries like "show all resources affected by this drift" and "visualize the topology of resources in this VPC."
+
+We considered several storage options:
+
+1. **External graph database** (Neo4j, Amazon Neptune) — Full-featured graph queries
+2. **External relational database** (PostgreSQL with recursive CTEs) — Familiar, widely deployed
+3. **In-memory graph store** — Custom Go implementation with adjacency lists
+4. **Embedded database** (BoltDB, BadgerDB) — Persistent, no external dependency
+
+## Decision
+
+We use a custom in-memory graph store (`pkg/graph/store.go`) backed by Go maps and adjacency lists. The store provides node/edge CRUD, neighbor traversal, subgraph extraction, and export capabilities (PNG, SVG, JSON).
+
+## Consequences
+
+### Positive
+
+- Zero external dependencies — no database to deploy or manage
+- Sub-millisecond query performance for typical graph sizes (< 10,000 nodes)
+- Simple deployment — single binary, no connection strings or migrations
+- Full control over query patterns optimized for our use cases
+- Export to multiple formats directly from memory
+
+### Negative
+
+- Data is lost on restart (no persistence)
+- Memory-bound — graph size limited by available RAM
+- No built-in Cypher/Gremlin query language — custom query API required
+- Scaling limited to single instance (no clustering)
+- Must implement our own concurrency control (sync.RWMutex)
+
+### Neutral
+
+- Suitable for the current scale (< 50,000 resources per instance)
+- A future ADR may supersede this if persistence or scale requirements change
+- The graph store interface is abstract enough to swap implementations later

--- a/docs/adr/003-multi-cloud-provider-abstraction.md
+++ b/docs/adr/003-multi-cloud-provider-abstraction.md
@@ -1,0 +1,50 @@
+# ADR-003: Multi-Cloud Provider Abstraction Pattern
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-22
+
+## Context
+
+TFDrift-Falco supports drift detection across AWS, GCP, and Azure. Each cloud provider has different audit log formats, API naming conventions, and Terraform resource type mappings. We needed a way to handle these differences without duplicating core logic.
+
+Options considered:
+
+1. **Single monolithic parser** — Handle all providers in one package with switch statements
+2. **Provider-specific packages** — Separate packages per provider with a common interface
+3. **Plugin architecture** — Dynamically loaded provider plugins
+
+## Decision
+
+We adopt provider-specific packages (`pkg/falco/` for AWS, `pkg/gcp/` for GCP, `pkg/azure/` for Azure) that share a common event type (`pkg/types/types.go`). Each provider has:
+
+- A **parser** that converts raw audit log events into the common `Event` type
+- A **resource mapper** that maps cloud API operations to Terraform resource types
+- A **mapping table** that defines the event-to-resource-type relationships
+
+The Falco subscriber routes events to the appropriate parser based on the event source field (`aws_cloudtrail`, `gcpaudit`, `azureaudit`).
+
+## Consequences
+
+### Positive
+
+- Clean separation of concerns — each provider is independent
+- Easy to add new providers without modifying existing code
+- Provider-specific logic is contained and testable in isolation
+- Common event type enables provider-agnostic downstream processing (drift detection, graph building, API responses)
+- Mapping tables are declarative and easy to extend
+
+### Negative
+
+- Some code duplication across providers (parser structure, mapping table format)
+- Adding a new provider requires understanding the pattern and creating multiple files
+- The common `Event` type must accommodate fields from all providers, leading to some optional fields
+
+### Neutral
+
+- AWS has the most mature mapping table (500+ events, 40+ services); GCP and Azure are catching up
+- Conflict resolution logic (`pkg/falco/mappings/conflicts.go`) handles overlapping event names across AWS services

--- a/docs/adr/004-dual-auth-jwt-apikey.md
+++ b/docs/adr/004-dual-auth-jwt-apikey.md
@@ -1,0 +1,55 @@
+# ADR-004: JWT + API Key Dual Authentication Strategy
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-22
+
+## Context
+
+TFDrift-Falco's REST API was initially open without authentication, suitable for development but not for enterprise deployment. We needed to add authentication that supports both:
+
+- **Interactive users** accessing the Dashboard UI (session-based, time-limited)
+- **Programmatic clients** (CI/CD pipelines, monitoring systems, scripts) that need persistent credentials
+
+Options considered:
+
+1. **JWT only** — Token-based auth for all clients
+2. **API Key only** — Static keys for all clients
+3. **OAuth 2.0** — Full OAuth flow with external identity provider
+4. **JWT + API Key dual authentication** — JWT for interactive, API Key for programmatic
+
+## Decision
+
+We implement dual authentication supporting both JWT Bearer tokens and API Keys (`pkg/api/middleware/auth.go`):
+
+- **JWT tokens** are issued via `POST /api/v1/auth/token` with configurable expiry and HMAC-SHA256 signing. They carry a subject (user identity) and are validated on each request.
+- **API Keys** use a `tfd_` prefix with 32 random hex bytes, validated via the `X-API-Key` header with constant-time comparison. Each key has a name, optional scopes, and creation timestamp.
+- When both are provided, JWT takes precedence.
+- Authentication is disabled by default (`auth.enabled: false`) for development ease.
+
+## Consequences
+
+### Positive
+
+- Two auth methods cover interactive and programmatic use cases
+- JWT provides time-limited tokens suitable for browser sessions
+- API Keys provide long-lived credentials for automation
+- Scoped API Keys enable fine-grained access control
+- Constant-time comparison prevents timing attacks on API Keys
+- Auth can be disabled for development/testing
+
+### Negative
+
+- Two auth methods increase middleware complexity
+- JWT secret must be securely managed (Kubernetes Secret, env var)
+- API Keys stored in config file — no built-in rotation mechanism yet
+- No integration with external identity providers (LDAP, OIDC) yet
+
+### Neutral
+
+- Rate limiting (`pkg/api/middleware/ratelimit.go`) uses the authenticated identity for per-client tracking
+- Public endpoints (`/health`, `/version`) bypass authentication

--- a/docs/adr/005-sse-websocket-realtime.md
+++ b/docs/adr/005-sse-websocket-realtime.md
@@ -1,0 +1,52 @@
+# ADR-005: SSE + WebSocket for Real-Time Communication
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-22
+
+## Context
+
+TFDrift-Falco's Dashboard UI needs to display drift events, alerts, and system status in real-time. The backend detects drift events continuously, and users expect to see them appear without refreshing the page.
+
+Options considered:
+
+1. **Polling** — Frontend polls API at regular intervals
+2. **Server-Sent Events (SSE) only** — Unidirectional server-to-client stream
+3. **WebSocket only** — Bidirectional communication channel
+4. **SSE + WebSocket hybrid** — SSE for notifications, WebSocket for interactive features
+
+## Decision
+
+We implement a hybrid approach using both SSE and WebSocket:
+
+- **SSE** (`/api/v1/stream`) — Used for push notifications (new drift events, alerts, status updates). The Go backend uses a Broadcaster pattern that fans out events to all connected SSE clients.
+- **WebSocket** (`/ws`) — Used for interactive features requiring bidirectional communication (future: live graph updates, collaborative features).
+
+The frontend SSE client (`ui/src/api/sseClient.ts`) manages connection lifecycle, automatic reconnection, and integrates with the Zustand toast store for user notifications.
+
+## Consequences
+
+### Positive
+
+- SSE is simple, uses standard HTTP, works through proxies/load balancers, and auto-reconnects
+- SSE is ideal for the primary use case (server pushing notifications to clients)
+- WebSocket provides a path for future bidirectional features
+- Broadcaster pattern efficiently fans out events to multiple clients
+- NotificationPanel provides real-time connection status (live/offline)
+
+### Negative
+
+- Two real-time protocols add complexity to both backend and frontend
+- SSE connections are long-lived, consuming server resources per connected client
+- WebSocket requires upgrade-aware proxy configuration
+- No message persistence — events missed during disconnection are lost
+
+### Neutral
+
+- SSE handles the majority of real-time needs; WebSocket is currently underutilized
+- Connection status indicator helps users understand when they're receiving live data
+- Future work may consolidate on WebSocket if bidirectional needs grow

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,27 @@
+# Architecture Decision Records (ADRs)
+
+This directory contains Architecture Decision Records for the TFDrift-Falco project.
+
+ADRs are short documents that capture important architectural decisions made along with their context and consequences. We follow the [Michael Nygard format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [ADR-000](000-use-adrs.md) | Use Architecture Decision Records | Accepted | 2026-03-22 |
+| [ADR-001](001-event-driven-falco-grpc.md) | Event-driven architecture with Falco gRPC | Accepted | 2026-03-22 |
+| [ADR-002](002-in-memory-graph-store.md) | In-memory graph store over external database | Accepted | 2026-03-22 |
+| [ADR-003](003-multi-cloud-provider-abstraction.md) | Multi-cloud provider abstraction pattern | Accepted | 2026-03-22 |
+| [ADR-004](004-dual-auth-jwt-apikey.md) | JWT + API Key dual authentication | Accepted | 2026-03-22 |
+| [ADR-005](005-sse-websocket-realtime.md) | SSE + WebSocket for real-time communication | Accepted | 2026-03-22 |
+
+## Template
+
+Use [ADR template](template.md) when creating new ADRs.
+
+## Statuses
+
+- **Proposed** — Under discussion
+- **Accepted** — Decision has been made and is in effect
+- **Deprecated** — No longer valid, superseded by another ADR
+- **Superseded** — Replaced by a newer ADR (link to replacement)

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,33 @@
+# ADR-NNN: Title
+
+## Status
+
+Proposed | Accepted | Deprecated | Superseded by [ADR-NNN](NNN-title.md)
+
+## Date
+
+YYYY-MM-DD
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+
+### Positive
+
+- ...
+
+### Negative
+
+- ...
+
+### Neutral
+
+- ...


### PR DESCRIPTION
## Summary
- Create ADR framework with index (`docs/adr/README.md`) and template (`docs/adr/template.md`)
- Add 6 ADRs documenting foundational architectural decisions:
  - **ADR-000**: Use Architecture Decision Records
  - **ADR-001**: Event-driven architecture with Falco gRPC
  - **ADR-002**: In-memory graph store over external database
  - **ADR-003**: Multi-cloud provider abstraction pattern
  - **ADR-004**: JWT + API Key dual authentication strategy
  - **ADR-005**: SSE + WebSocket for real-time communication

## Test plan
- [ ] Verify ADR index links resolve correctly
- [ ] Verify each ADR follows the Nygard format (Status, Date, Context, Decision, Consequences)
- [ ] Verify template is usable for future ADRs

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)