### PR TITLE
chore: Add pre-commit hooks and commitlint (#61)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,46 @@
+# Pre-commit hooks — https://pre-commit.com
+# Install: pip install pre-commit && pre-commit install
+repos:
+  # General file checks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: detect-private-key
+
+  # Go
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-fmt
+      - id: go-vet
+      - id: go-mod-tidy
+
+  # Commit message linting (conventional commits)
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args:
+          - feat
+          - fix
+          - docs
+          - style
+          - refactor
+          - perf
+          - test
+          - build
+          - ci
+          - chore
+          - revert
+          - deps
+          - release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,13 +66,31 @@ git remote add upstream https://github.com/higakikeita/tfdrift-falco.git
 ### 2. Install Dependencies
 
 ```bash
-# Download Go dependencies
-go mod download
+# Initialize development environment (deps + tools + hooks)
+make init
 
-# Install development tools
+# Or manually:
+go mod download
 go install golang.org/x/tools/cmd/goimports@latest
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 ```
+
+### 2b. Set Up Pre-commit Hooks (Recommended)
+
+Pre-commit hooks enforce code quality and conventional commit messages automatically:
+
+```bash
+# Install pre-commit (if not already installed)
+pip install pre-commit
+
+# Install hooks (done automatically by `make init` if pre-commit is available)
+make setup-hooks
+```
+
+This installs hooks for:
+- Trailing whitespace, end-of-file fixes, YAML/JSON validation
+- Go formatting (`gofmt`), vetting (`go vet`), module tidying
+- Conventional commit message validation (commit-msg hook)
 
 ### 3. Build the Project
 
@@ -339,8 +357,16 @@ We follow the [Conventional Commits](https://www.conventionalcommits.org/) speci
 - `docs:` Documentation changes
 - `style:` Code style changes (formatting, etc.)
 - `refactor:` Code refactoring
+- `perf:` Performance improvement
 - `test:` Adding or updating tests
-- `chore:` Build process or auxiliary tool changes
+- `build:` Build system or external dependencies
+- `ci:` CI/CD configuration
+- `chore:` Maintenance tasks
+- `revert:` Revert a previous commit
+- `deps:` Dependency updates
+- `release:` Release commits
+
+Commit messages are validated by pre-commit hooks (see [commitlint.config.js](commitlint.config.js)).
 
 ### Examples
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean install lint fmt help
+.PHONY: build test clean install lint fmt help setup-hooks
 
 # Variables
 BINARY_NAME=tfdrift
@@ -183,6 +183,14 @@ run-dry: build
 	@echo "Running $(BINARY_NAME) in dry-run mode..."
 	$(BUILD_DIR)/$(BINARY_NAME) --config examples/config.yaml --dry-run
 
+## setup-hooks: Install pre-commit hooks
+setup-hooks:
+	@echo "Installing pre-commit hooks..."
+	@which pre-commit > /dev/null || (echo "pre-commit not installed. Run: pip install pre-commit" && exit 1)
+	pre-commit install
+	pre-commit install --hook-type commit-msg
+	@echo "Pre-commit hooks installed!"
+
 ## init: Initialize development environment
 init:
 	@echo "Initializing development environment..."
@@ -190,6 +198,8 @@ init:
 	@echo "Installing development tools..."
 	$(GO) install golang.org/x/tools/cmd/goimports@latest
 	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@echo "Setting up pre-commit hooks (if pre-commit is available)..."
+	@which pre-commit > /dev/null && $(MAKE) setup-hooks || echo "pre-commit not found, skipping hooks setup"
 	@echo "Development environment ready!"
 
 ## check: Run all checks (fmt, lint, test)

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,37 @@
+// Conventional Commits configuration
+// https://www.conventionalcommits.org/
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Allowed commit types
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',     // New feature
+        'fix',      // Bug fix
+        'docs',     // Documentation only
+        'style',    // Code style (formatting, semicolons, etc.)
+        'refactor', // Code refactoring (no feature/fix change)
+        'perf',     // Performance improvement
+        'test',     // Adding or updating tests
+        'build',    // Build system or external dependencies
+        'ci',       // CI/CD configuration
+        'chore',    // Maintenance tasks
+        'revert',   // Revert a previous commit
+        'deps',     // Dependency updates
+        'release',  // Release commits
+      ],
+    ],
+    // Subject must not be empty
+    'subject-empty': [2, 'never'],
+    // Type must not be empty
+    'type-empty': [2, 'never'],
+    // Subject max length
+    'subject-max-length': [1, 'always', 100],
+    // Header max length
+    'header-max-length': [2, 'always', 120],
+    // Body max line length (warning only)
+    'body-max-line-length': [1, 'always', 200],
+  },
+};


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with Go formatting/vetting hooks, file quality checks, and conventional commit validation
- Add `commitlint.config.js` with project-specific commit types (feat, fix, docs, deps, release, etc.)
- Add `make setup-hooks` target and integrate hook setup into `make init`
- Update CONTRIBUTING.md with pre-commit setup instructions and expanded commit type documentation

## Test plan
- [ ] Verify `.pre-commit-config.yaml` syntax is valid
- [ ] Verify `commitlint.config.js` exports valid configuration
- [ ] Verify `make setup-hooks` target exists in Makefile
- [ ] Verify CONTRIBUTING.md documents the setup process

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)