### PR TITLE
fix: resolve go mod tidy, Azure test, and frontend test failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/falcosecurity/client-go v0.6.1
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-chi/cors v1.2.2
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/prometheus/client_golang v1.23.2
@@ -62,7 +63,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.7 // indirect

--- a/pkg/azure/audit_parser.go
+++ b/pkg/azure/audit_parser.go
@@ -271,9 +271,9 @@ func extractResourceName(resourceID string) string {
 
 // extractResourceGroup extracts the resource group from an Azure resource ID
 func extractResourceGroup(resourceID string) string {
-	parts := strings.Split(strings.ToLower(resourceID), "/")
+	parts := strings.Split(resourceID, "/")
 	for i, part := range parts {
-		if part == "resourcegroups" && i+1 < len(parts) {
+		if strings.EqualFold(part, "resourcegroups") && i+1 < len(parts) {
 			return parts[i+1]
 		}
 	}
@@ -282,9 +282,9 @@ func extractResourceGroup(resourceID string) string {
 
 // extractSubscriptionID extracts the subscription ID from an Azure resource ID
 func extractSubscriptionID(resourceID string) string {
-	parts := strings.Split(strings.ToLower(resourceID), "/")
+	parts := strings.Split(resourceID, "/")
 	for i, part := range parts {
-		if part == "subscriptions" && i+1 < len(parts) {
+		if strings.EqualFold(part, "subscriptions") && i+1 < len(parts) {
 			return parts[i+1]
 		}
 	}

--- a/ui/src/components/ConnectionStatus.test.tsx
+++ b/ui/src/components/ConnectionStatus.test.tsx
@@ -1,19 +1,37 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 
-vi.mock('lucide-react', () => new Proxy({}, {
-  get: (_, name) => () => <div data-testid={`icon-${String(name)}`} />,
+vi.mock('lucide-react', () => ({
+  Wifi: () => <div data-testid="wifi-icon" />,
+  WifiOff: () => <div data-testid="wifioff-icon" />,
+  Activity: () => <div data-testid="activity-icon" />,
+  Radio: () => <div data-testid="radio-icon" />,
 }));
 
 vi.mock('../api/sse', () => ({
+  useSSE: () => ({
+    isConnected: true,
+    lastEvent: null,
+    events: [],
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }),
   sseClient: { connect: vi.fn(), disconnect: vi.fn(), on: vi.fn(), off: vi.fn() },
 }));
 
 vi.mock('../api/websocket', () => ({
+  useWebSocket: () => ({
+    isConnected: false,
+    lastMessage: null,
+    messages: [],
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    send: vi.fn(),
+  }),
   wsClient: { connect: vi.fn(), disconnect: vi.fn(), on: vi.fn(), off: vi.fn() },
 }));
 
-import ConnectionStatus from './ConnectionStatus';
+import { ConnectionStatus } from './ConnectionStatus';
 
 describe('ConnectionStatus', () => {
   it('should render without crashing', () => {

--- a/ui/src/components/ThemeToggle.test.tsx
+++ b/ui/src/components/ThemeToggle.test.tsx
@@ -6,7 +6,15 @@ vi.mock('lucide-react', () => ({
   Moon: () => <div data-testid="moon-icon" />,
 }));
 
-import ThemeToggle from './ThemeToggle';
+vi.mock('../hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: 'light',
+    setTheme: vi.fn(),
+    toggleTheme: vi.fn(),
+  }),
+}));
+
+import { ThemeToggle } from './ThemeToggle';
 
 describe('ThemeToggle', () => {
   it('should render without crashing', () => {

--- a/ui/src/components/analytics/SeverityChart.test.tsx
+++ b/ui/src/components/analytics/SeverityChart.test.tsx
@@ -15,14 +15,14 @@ vi.mock('recharts', () => ({
   CartesianGrid: () => <div data-testid="grid" />,
 }));
 
-import SeverityChart from './SeverityChart';
+import { SeverityChart } from './SeverityChart';
 
-const mockData = {
-  critical: 5,
-  high: 10,
-  medium: 15,
-  low: 20,
-};
+const mockData = [
+  { name: 'Critical', value: 5, fill: '#ef4444' },
+  { name: 'High', value: 10, fill: '#f97316' },
+  { name: 'Medium', value: 15, fill: '#eab308' },
+  { name: 'Low', value: 20, fill: '#3b82f6' },
+];
 
 describe('SeverityChart', () => {
   it('should render without crashing', () => {

--- a/ui/src/components/analytics/TimelineChart.test.tsx
+++ b/ui/src/components/analytics/TimelineChart.test.tsx
@@ -14,7 +14,7 @@ vi.mock('recharts', () => ({
   Area: () => <div data-testid="area" />,
 }));
 
-import TimelineChart from './TimelineChart';
+import { TimelineChart } from './TimelineChart';
 
 const mockData = [
   { date: '03/20', aws: 5, gcp: 3 },

--- a/ui/src/components/events/EventFilters.test.tsx
+++ b/ui/src/components/events/EventFilters.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-vi.mock('lucide-react', () => new Proxy({}, {
-  get: (_, name) => () => <div data-testid={`icon-${String(name)}`} />,
+vi.mock('lucide-react', () => ({
+  Search: () => <div data-testid="icon-Search" />,
+  X: () => <div data-testid="icon-X" />,
 }));
 
-import EventFilters from './EventFilters';
+import { EventFilters } from './EventFilters';
 
 const defaultFilters = {
   severity: '',
@@ -17,24 +18,24 @@ const defaultFilters = {
 describe('EventFilters', () => {
   it('should render without crashing', () => {
     const { container } = render(
-      <EventFilters filters={defaultFilters} onFiltersChange={vi.fn()} />
+      <EventFilters filters={defaultFilters} onChange={vi.fn()} totalCount={0} filteredCount={0} />
     );
     expect(container.firstChild).toBeTruthy();
   });
 
   it('should render filter inputs', () => {
     render(
-      <EventFilters filters={defaultFilters} onFiltersChange={vi.fn()} />
+      <EventFilters filters={defaultFilters} onChange={vi.fn()} totalCount={0} filteredCount={0} />
     );
     // Should have form elements (select, input, etc.)
     const inputs = document.querySelectorAll('input, select, button');
     expect(inputs.length).toBeGreaterThan(0);
   });
 
-  it('should call onFiltersChange when a filter changes', () => {
+  it('should call onChange when a filter changes', () => {
     const onChange = vi.fn();
     render(
-      <EventFilters filters={defaultFilters} onFiltersChange={onChange} />
+      <EventFilters filters={defaultFilters} onChange={onChange} totalCount={0} filteredCount={0} />
     );
     // Find any interactive element and interact
     const selects = document.querySelectorAll('select');

--- a/ui/src/components/events/EventTable.test.tsx
+++ b/ui/src/components/events/EventTable.test.tsx
@@ -2,11 +2,13 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-vi.mock('lucide-react', () => new Proxy({}, {
-  get: (_, name) => () => <div data-testid={`icon-${String(name)}`} />,
+vi.mock('lucide-react', () => ({
+  ArrowUpDown: () => <div data-testid="icon-ArrowUpDown" />,
+  ChevronLeft: () => <div data-testid="icon-ChevronLeft" />,
+  ChevronRight: () => <div data-testid="icon-ChevronRight" />,
 }));
 
-import EventTable from './EventTable';
+import { EventTable } from './EventTable';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
@@ -16,35 +18,39 @@ const mockEvents = [
   {
     id: 'evt-1',
     provider: 'aws',
-    event_name: 'ModifySecurityGroupRules',
-    resource_type: 'aws_security_group',
-    resource_id: 'sg-12345',
-    user_identity: 'admin',
     timestamp: '2026-03-22T10:00:00Z',
     severity: 'critical',
-    status: 'open',
+    resourceType: 'aws_security_group',
+    resourceId: 'sg-12345',
+    resourceName: 'SecurityGroup-1',
+    changeType: 'modified',
+    attribute: 'ingress_rules',
+    oldValue: null,
+    newValue: null,
+    userIdentity: { type: 'IAMUser', userName: 'admin', arn: 'arn:aws:iam::123456789:user/admin', accountId: '123456789' },
     region: 'us-east-1',
-    service_name: 'EC2',
   },
   {
     id: 'evt-2',
     provider: 'gcp',
-    event_name: 'compute.firewalls.patch',
-    resource_type: 'google_compute_firewall',
-    resource_id: 'fw-allow-ssh',
-    user_identity: 'user@project.iam.gserviceaccount.com',
     timestamp: '2026-03-22T09:00:00Z',
     severity: 'high',
-    status: 'acknowledged',
+    resourceType: 'google_compute_firewall',
+    resourceId: 'fw-allow-ssh',
+    resourceName: 'firewall-allow-ssh',
+    changeType: 'modified',
+    attribute: 'source_ranges',
+    oldValue: null,
+    newValue: null,
+    userIdentity: { type: 'ServiceAccount', userName: 'user@project.iam.gserviceaccount.com', arn: '', accountId: '' },
     region: 'us-central1',
-    service_name: 'Compute Engine',
   },
 ];
 
-const renderTable = (events = mockEvents, onSelect = vi.fn()) => {
+const renderTable = (events = mockEvents, onEventClick = vi.fn()) => {
   return render(
     <QueryClientProvider client={queryClient}>
-      <EventTable events={events} onSelectEvent={onSelect} />
+      <EventTable events={events} onEventClick={onEventClick} />
     </QueryClientProvider>
   );
 };

--- a/ui/src/components/graph/GraphExportButton.test.tsx
+++ b/ui/src/components/graph/GraphExportButton.test.tsx
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-vi.mock('lucide-react', () => new Proxy({}, {
-  get: (_, name) => () => <div data-testid={`icon-${String(name)}`} />,
+vi.mock('lucide-react', () => ({
+  Download: () => <div data-testid="icon-Download" />,
+  Image: () => <div data-testid="icon-Image" />,
+  FileCode: () => <div data-testid="icon-FileCode" />,
+  FileJson: () => <div data-testid="icon-FileJson" />,
+  ChevronDown: () => <div data-testid="icon-ChevronDown" />,
 }));
 
-import GraphExportButton from './GraphExportButton';
+import { GraphExportButton } from './GraphExportButton';
 
 describe('GraphExportButton', () => {
   it('should render without crashing', () => {

--- a/ui/src/components/layout/Header.test.tsx
+++ b/ui/src/components/layout/Header.test.tsx
@@ -21,6 +21,13 @@ vi.mock('lucide-react', () => ({
 }));
 
 vi.mock('../../api/sse', () => ({
+  useSSE: () => ({
+    isConnected: true,
+    lastEvent: null,
+    events: [],
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  }),
   sseClient: {
     connect: vi.fn(),
     disconnect: vi.fn(),
@@ -29,7 +36,11 @@ vi.mock('../../api/sse', () => ({
   },
 }));
 
-import Header from './Header';
+vi.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'light', setTheme: vi.fn(), toggleTheme: vi.fn() }),
+}));
+
+import { Header } from './Header';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },

--- a/ui/src/components/layout/Sidebar.test.tsx
+++ b/ui/src/components/layout/Sidebar.test.tsx
@@ -14,9 +14,10 @@ vi.mock('lucide-react', () => ({
   ChevronRight: () => <div data-testid="chevron-right" />,
   GitCompare: () => <div data-testid="git-compare" />,
   Activity: () => <div data-testid="activity-icon" />,
+  Shield: () => <div data-testid="shield-icon" />,
 }));
 
-import Sidebar from './Sidebar';
+import { Sidebar } from './Sidebar';
 
 const renderSidebar = () => {
   return render(

--- a/ui/src/pages/DashboardPage.test.tsx
+++ b/ui/src/pages/DashboardPage.test.tsx
@@ -3,8 +3,11 @@ import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 
-vi.mock('lucide-react', () => new Proxy({}, {
-  get: (_, name) => () => <div data-testid={`icon-${String(name)}`} />,
+vi.mock('lucide-react', () => ({
+  Activity: () => <div data-testid="icon-Activity" />,
+  AlertTriangle: () => <div data-testid="icon-AlertTriangle" />,
+  CheckCircle: () => <div data-testid="icon-CheckCircle" />,
+  Cloud: () => <div data-testid="icon-Cloud" />,
 }));
 
 vi.mock('../api/client', () => ({
@@ -22,7 +25,7 @@ vi.mock('../api/sse', () => ({
   sseClient: { connect: vi.fn(), disconnect: vi.fn(), on: vi.fn(), off: vi.fn() },
 }));
 
-import DashboardPage from './DashboardPage';
+import { DashboardPage } from './DashboardPage';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false, gcTime: 0 } },

--- a/ui/src/pages/EventsPage.test.tsx
+++ b/ui/src/pages/EventsPage.test.tsx
@@ -3,8 +3,22 @@ import { render } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 
-vi.mock('lucide-react', () => new Proxy({}, {
-  get: (_, name) => () => <div data-testid={`icon-${String(name)}`} />,
+vi.mock('lucide-react', () => ({
+  ArrowUpDown: () => <div data-testid="icon-ArrowUpDown" />,
+  ChevronLeft: () => <div data-testid="icon-ChevronLeft" />,
+  ChevronRight: () => <div data-testid="icon-ChevronRight" />,
+  X: () => <div data-testid="icon-X" />,
+  Search: () => <div data-testid="icon-Search" />,
+  Clock: () => <div data-testid="icon-Clock" />,
+  AlertCircle: () => <div data-testid="icon-AlertCircle" />,
+  CheckCircle: () => <div data-testid="icon-CheckCircle" />,
+  CheckCircle2: () => <div data-testid="icon-CheckCircle2" />,
+  Circle: () => <div data-testid="icon-Circle" />,
+  EyeOff: () => <div data-testid="icon-EyeOff" />,
+  Shield: () => <div data-testid="icon-Shield" />,
+  User: () => <div data-testid="icon-User" />,
+  MapPin: () => <div data-testid="icon-MapPin" />,
+  Activity: () => <div data-testid="icon-Activity" />,
 }));
 
 vi.mock('../api/client', () => ({
@@ -22,7 +36,7 @@ vi.mock('../api/sse', () => ({
   sseClient: { connect: vi.fn(), disconnect: vi.fn(), on: vi.fn(), off: vi.fn() },
 }));
 
-import EventsPage from './EventsPage';
+import { EventsPage } from './EventsPage';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false, gcTime: 0 } },

--- a/ui/src/pages/SettingsPage.test.tsx
+++ b/ui/src/pages/SettingsPage.test.tsx
@@ -3,8 +3,15 @@ import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 
-vi.mock('lucide-react', () => new Proxy({}, {
-  get: (_, name) => () => <div data-testid={`icon-${String(name)}`} />,
+vi.mock('lucide-react', () => ({
+  Plus: () => <div data-testid="icon-Plus" />,
+  Trash2: () => <div data-testid="icon-Trash2" />,
+  TestTube: () => <div data-testid="icon-TestTube" />,
+  Save: () => <div data-testid="icon-Save" />,
+  Webhook: () => <div data-testid="icon-Webhook" />,
+  Shield: () => <div data-testid="icon-Shield" />,
+  Cloud: () => <div data-testid="icon-Cloud" />,
+  Settings: () => <div data-testid="icon-Settings" />,
 }));
 
 vi.mock('../api/client', () => ({
@@ -14,7 +21,7 @@ vi.mock('../api/client', () => ({
   },
 }));
 
-import SettingsPage from './SettingsPage';
+import { SettingsPage } from './SettingsPage';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false, gcTime: 0 } },

--- a/ui/src/utils/reactFlowAdapter.test.ts
+++ b/ui/src/utils/reactFlowAdapter.test.ts
@@ -81,7 +81,7 @@ describe('reactFlowAdapter', () => {
         type: 'custom',
         data: {
           label: 'IAM Role',
-          type: 'aws_iam_role',
+          type: 'iam_role',
           severity: 'high'
         }
       });


### PR DESCRIPTION
## Summary

- **go.mod**: `golang-jwt/jwt/v5` を indirect → direct に移動（CI の `go mod tidy` チェック修正）
- **Azure**: `extractResourceGroup` の大文字小文字バグを修正（`strings.ToLower` → `strings.EqualFold`）
- **Frontend**: 12テストファイルのインポート不一致、モック不足、テストデータ構造の修正

### テスト結果

| Before | After |
|--------|-------|
| ~9 failing test files | **26/26 pass** |
| ~15+ failing tests | **304/304 pass** |
| `go mod tidy` CI failure | Fixed |
| Azure `TestExtractResourceGroup` failure | Fixed |

### 修正内容

- default import → named import（12ファイル）
- `new Proxy` lucide-react モック → 明示的モック（vitest ハングの原因）
- `useSSE`, `useWebSocket`, `useTheme` フックモック追加
- `EventFilters`, `EventTable`, `SeverityChart`, `reactFlowAdapter` テストデータ修正

## Test plan

- [x] `npx vitest run` — 26ファイル 304テスト全パス
- [ ] CI Backend job の `go mod tidy` チェック通過
- [ ] CI Frontend job のテスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)