### PR TITLE
fix: critical concurrency bugs and silent error handling

### DIFF
--- a/pkg/api/websocket/client.go
+++ b/pkg/api/websocket/client.go
@@ -43,6 +43,9 @@ type Client struct {
 
 	// Mutex for subscription operations
 	mu sync.RWMutex
+
+	// closeOnce ensures send channel is closed exactly once, preventing double-close panics
+	closeOnce sync.Once
 }
 
 // WSMessage represents a WebSocket message
@@ -70,6 +73,13 @@ func newClient(hub *Hub, conn *websocket.Conn) *Client {
 		send:          make(chan []byte, 256),
 		subscriptions: make(map[string]bool),
 	}
+}
+
+// CloseOnce safely closes the send channel exactly once, preventing double-close panics
+func (c *Client) CloseOnce() {
+	c.closeOnce.Do(func() {
+		close(c.send)
+	})
 }
 
 // readPump pumps messages from the WebSocket connection to the hub

--- a/pkg/api/websocket/hub.go
+++ b/pkg/api/websocket/hub.go
@@ -63,25 +63,36 @@ func (h *Hub) Run() {
 			h.mu.Lock()
 			if _, ok := h.clients[client]; ok {
 				delete(h.clients, client)
-				close(client.send)
+				client.CloseOnce()
 				log.Infof("WebSocket client unregistered: %s (total: %d)", client.id, len(h.clients))
 			}
 			h.mu.Unlock()
 
 		case message := <-h.broadcast:
+			// FIX: Collect clients to remove under RLock, then remove under Lock
 			h.mu.RLock()
+			var toRemove []*Client
 			for client := range h.clients {
-				// Only send to clients subscribed to this message type
-				// For now, send to all clients
 				select {
 				case client.send <- message:
 				default:
-					// Client's send buffer is full, close it
-					close(client.send)
-					delete(h.clients, client)
+					// Client's send buffer is full, mark for removal
+					toRemove = append(toRemove, client)
 				}
 			}
 			h.mu.RUnlock()
+
+			// Remove stale clients under write lock
+			if len(toRemove) > 0 {
+				h.mu.Lock()
+				for _, client := range toRemove {
+					if _, ok := h.clients[client]; ok {
+						delete(h.clients, client)
+						client.CloseOnce()
+					}
+				}
+				h.mu.Unlock()
+			}
 
 		case event := <-h.eventCh:
 			// Broadcast event to all connected clients

--- a/pkg/config/autodetect.go
+++ b/pkg/config/autodetect.go
@@ -30,7 +30,11 @@ type AutoDetectResult struct {
 // 3. Check for backend "s3" configuration in .tf files (S3 backend)
 func AutoDetectTerraformState(searchPath string) (*AutoDetectResult, error) {
 	if searchPath == "" {
-		searchPath, _ = os.Getwd()
+		var err error
+		searchPath, err = os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get working directory: %w", err)
+		}
 	}
 
 	result := &AutoDetectResult{
@@ -51,7 +55,7 @@ func AutoDetectTerraformState(searchPath string) (*AutoDetectResult, error) {
 		result.Found = true
 		result.Backend = "local"
 		result.LocalPath = localStatePath
-		result.Message = fmt.Sprintf("✓ Detected local Terraform state: %s", localStatePath)
+		result.Message = fmt.Sprintf("â Detected local Terraform state: %s", localStatePath)
 		return result, nil
 	}
 
@@ -63,7 +67,7 @@ func AutoDetectTerraformState(searchPath string) (*AutoDetectResult, error) {
 		result.S3Bucket = s3Config.Bucket
 		result.S3Key = s3Config.Key
 		result.S3Region = s3Config.Region
-		result.Message = fmt.Sprintf("✓ Detected S3 backend: s3://%s/%s (region: %s)",
+		result.Message = fmt.Sprintf("â Detected S3 backend: s3://%s/%s (region: %s)",
 			s3Config.Bucket, s3Config.Key, s3Config.Region)
 		return result, nil
 	}
@@ -193,13 +197,13 @@ func CreateAutoConfig(result *AutoDetectResult) (*Config, error) {
 
 // PrintAutoDetectHelp prints helpful information when auto-detection fails
 func PrintAutoDetectHelp(result *AutoDetectResult) {
-	fmt.Println("\n" + strings.Repeat("━", 60))
-	fmt.Println("🔍 Terraform State Auto-Detection")
-	fmt.Println(strings.Repeat("━", 60))
+	fmt.Println("\n" + strings.Repeat("â", 60))
+	fmt.Println("ð Terraform State Auto-Detection")
+	fmt.Println(strings.Repeat("â", 60))
 	fmt.Println()
 
 	if result.Found {
-		fmt.Println("✓ " + result.Message)
+		fmt.Println("â " + result.Message)
 		fmt.Println()
 		fmt.Println("Auto-detected configuration:")
 		fmt.Printf("  Backend: %s\n", result.Backend)
@@ -211,9 +215,9 @@ func PrintAutoDetectHelp(result *AutoDetectResult) {
 			fmt.Printf("  Region:  %s\n", result.S3Region)
 		}
 	} else {
-		fmt.Println("❌ " + result.Message)
+		fmt.Println("â " + result.Message)
 		fmt.Println()
-		fmt.Println("💡 Quick Start Guide:")
+		fmt.Println("ð¡ Quick Start Guide:")
 		fmt.Println()
 		fmt.Println("  1. If you have Terraform initialized in this directory:")
 		fmt.Println("     cd path/to/terraform/directory")
@@ -239,6 +243,6 @@ func PrintAutoDetectHelp(result *AutoDetectResult) {
 		fmt.Println()
 	}
 
-	fmt.Println(strings.Repeat("━", 60))
+	fmt.Println(strings.Repeat("â", 60))
 	fmt.Println()
 }

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -107,7 +107,7 @@ func (m *Manager) formatSlackMessage(alert *types.DriftAlert) []map[string]inter
 				},
 				{
 					"type": "mrkdwn",
-					"text": fmt.Sprintf("*Changed:*\n`%v` → `%v`", alert.OldValue, alert.NewValue),
+					"text": fmt.Sprintf("*Changed:*\n`%v` â `%v`", alert.OldValue, alert.NewValue),
 				},
 				{
 					"type": "mrkdwn",
@@ -195,7 +195,10 @@ func (m *Manager) sendFalcoOutput(alert *types.DriftAlert) error {
 
 	// Falco integration stub - intentionally a no-op until Falco gRPC integration is fully implemented.
 	// Future implementation will send events to Falco gRPC endpoint or write to Falco output file.
-	jsonData, _ := json.MarshalIndent(falcoEvent, "", "  ")
+	jsonData, err := json.MarshalIndent(falcoEvent, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal Falco event: %w", err)
+	}
 	log.WithFields(log.Fields{
 		"alert_type":    "drift",
 		"resource_type": alert.ResourceType,

--- a/pkg/output/webhook.go
+++ b/pkg/output/webhook.go
@@ -129,7 +129,10 @@ func (w *WebhookOutput) send(jsonData []byte) error {
 
 	// Check status code
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("webhook returned status %d (failed to read body: %v)", resp.StatusCode, readErr)
+		}
 		return fmt.Errorf("webhook returned status %d: %s", resp.StatusCode, string(body))
 	}
 


### PR DESCRIPTION
## Summary

- **Fix data race in WebSocket Hub broadcast** (CRITICAL): `RLock()` was held while calling `delete()` and `close()` on the clients map. Replaced with `toRemove` pattern — collect stale clients under `RLock`, then remove under `Lock`.
- **Fix double-close panic on WebSocket client send channel** (CRITICAL): Added `sync.Once`-based `CloseOnce()` method to prevent panics when multiple goroutines attempt to close the same channel.
- **Fix silent error in `autodetect.go`** (HIGH): `os.Getwd()` error was silently discarded with `_`. Now returns a wrapped error.
- **Fix silent error in `webhook.go`** (HIGH): `io.ReadAll()` error was silently discarded. Now returns distinct error messages for read failure vs. HTTP error.
- **Fix silent error in `notifier.go`** (HIGH): `json.MarshalIndent()` error was silently discarded. Now returns a wrapped error.

## Files Changed

| File | Severity | Bug |
|------|----------|-----|
| `pkg/api/websocket/hub.go` | Critical | Data race: RLock + map mutation |
| `pkg/api/websocket/client.go` | Critical | Double-close panic on channel |
| `pkg/config/autodetect.go` | High | Silent error on os.Getwd() |
| `pkg/output/webhook.go` | High | Silent error on io.ReadAll() |
| `pkg/notifier/notifier.go` | High | Silent error on json.MarshalIndent() |

## Test plan

- [ ] Verify `go build ./...` compiles successfully
- [ ] Verify `go vet ./...` passes with no race warnings
- [ ] Run `go test -race ./pkg/api/websocket/...` to confirm no data races
- [ ] Review diff for each file to confirm correctness
