### PR TITLE
ci(release): fix invalid image tag on tag builds

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -85,7 +85,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha,prefix={{branch}}-
+            # NOTE: {{branch}} is empty on tag builds, which used to produce
+            # the invalid tag ":-<sha>" and kill buildx before building.
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Summary

The v0.13.0 publish attempt got past the new version-consistency gate ✅ and then failed with:

```
invalid tag "ghcr.io/higakikeita/tfdrift-falco:-4d34128": invalid reference format
```

`type=sha,prefix={{branch}}-` expands `{{branch}}` to an **empty string on tag builds**, producing `:-<sha>` — buildx dies validating tags before any build starts. The timing (~30s) matches every historical publish failure since v0.6.0, so this was the first domino all along; the missing QEMU (#278) was the second, waiting behind it.

Fix: use `type=sha` (default `sha-` prefix), valid for every event type.

Per the runbook, v0.13.0 will be deleted and re-cut once this merges (unpublished tags may be re-cut, no version bump).

Tracking: #279 (step 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)