### PR TITLE
fix(quickstart): make README Quick Start actually work on a clean clone

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -84,6 +84,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
+            # Also publish the v-prefixed tag verbatim (docker pull ...:v0.13.0)
+            type=semver,pattern={{raw}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             # NOTE: {{branch}} is empty on tag builds, which used to produce

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -42,9 +42,10 @@ jobs:
           TAG="${GITHUB_REF_NAME#v}"
           FILE_VERSION="$(tr -d '[:space:]' < VERSION)"
           CHANGELOG_VERSION="$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+[^]]*\]' CHANGELOG.md | tr -d '#[] ')"
-          echo "tag=v${TAG} VERSION=${FILE_VERSION} CHANGELOG=${CHANGELOG_VERSION}"
-          if [ "${TAG}" != "${FILE_VERSION}" ] || [ "${TAG}" != "${CHANGELOG_VERSION}" ]; then
-            echo "::error::Version identity mismatch: tag=v${TAG} VERSION=${FILE_VERSION} CHANGELOG=${CHANGELOG_VERSION}. Align them before releasing (ADR-0002)."
+          BINARY_VERSION="$(grep -m1 -oE 'version += +"[0-9]+\.[0-9]+\.[0-9]+"' cmd/tfdrift/main.go | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+          echo "tag=v${TAG} VERSION=${FILE_VERSION} CHANGELOG=${CHANGELOG_VERSION} binary=${BINARY_VERSION}"
+          if [ "${TAG}" != "${FILE_VERSION}" ] || [ "${TAG}" != "${CHANGELOG_VERSION}" ] || [ "${TAG}" != "${BINARY_VERSION}" ]; then
+            echo "::error::Version identity mismatch: tag=v${TAG} VERSION=${FILE_VERSION} CHANGELOG=${CHANGELOG_VERSION} binary=${BINARY_VERSION}. Align them before releasing (ADR-0002)."
             exit 1
           fi
           echo "✅ Version identity consistent: v${TAG}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,13 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build binary with optimization flags
+# Build binary with optimization flags.
+# VERSION comes from the workflow (tag name); git describe is only a
+# fallback and yields 'dev' in CI because .dockerignore excludes .git.
+ARG VERSION=
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -a -installsuffix cgo \
-    -ldflags="-s -w -X main.version=$(git describe --tags --always --dirty 2>/dev/null || echo 'dev')" \
+    -ldflags="-s -w -X main.version=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo 'dev')}" \
     -o tfdrift \
     ./cmd/tfdrift
 

--- a/README.md
+++ b/README.md
@@ -30,16 +30,20 @@ Someone modifies a security group via AWS Console
 
 ## Quick Start
 
+**Try the API server locally** (Go 1.25+, no cloud credentials needed to boot):
+
 ```bash
-# Clone and configure
 git clone https://github.com/higakikeita/tfdrift-falco.git && cd tfdrift-falco
-cp config.yaml.example config.yaml  # Edit with your settings
+cp config.yaml.example config.yaml   # edit with your settings
+go run ./cmd/tfdrift --server --config config.yaml
+# → http://localhost:8080/api/v1/health
+```
 
-# Launch
+**Full stack with Falco** (Docker + Docker Compose):
+
+```bash
+./quick-start.sh        # generates config, TLS certs, .env (interactive; --yes for defaults)
 docker compose up -d
-
-# Or try demo mode (no cloud credentials needed)
-go run ./cmd/tfdrift --demo
 ```
 
 See [Getting Started Guide](docs/GETTING_STARTED.md) for detailed setup.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ go run ./cmd/tfdrift --server --config config.yaml
 docker compose up -d
 ```
 
+> **Note**: the `falco` service captures syscalls and needs a Linux host; on macOS/Windows (Docker Desktop) it will crash-loop on `scap_init`, while the backend/frontend run fine. For CloudTrail-based drift detection, configure the Falco CloudTrail plugin instead — see [docs/complete-setup-guide.md](docs/complete-setup-guide.md).
+
 See [Getting Started Guide](docs/GETTING_STARTED.md) for detailed setup.
 
 ---

--- a/cmd/tfdrift/main.go
+++ b/cmd/tfdrift/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	version     = "0.4.1"
+	version     = "0.13.0"
 	cfgFile     string
 	autoDetect  bool
 	outputMode  string

--- a/cmd/tfdrift/main_test.go
+++ b/cmd/tfdrift/main_test.go
@@ -172,7 +172,9 @@ func TestNewApprovalCleanupCmd_CustomDuration(t *testing.T) {
 
 func TestVersion(t *testing.T) {
 	assert.NotEmpty(t, version)
-	assert.Equal(t, "0.4.1", version)
+	// Pin the shape, not the value: the exact version is asserted against
+	// the VERSION file by the release workflow's consistency gate.
+	assert.Regexp(t, `^\d+\.\d+\.\d+$`, version)
 }
 
 func TestLoggerOutput(t *testing.T) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,9 @@ services:
       - tfdrift
     command: ["--server", "--api-port", "8080", "--config", "/config/config.yaml"]
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      # GET, not --spider: --spider probes with HEAD, which the router
+      # answers 405, leaving the service permanently "unhealthy".
+      test: ["CMD", "wget", "--quiet", "--tries=1", "-O", "/dev/null", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -2,14 +2,22 @@
 set -e
 
 # TFDrift-Falco Quick Start Setup
-# This script sets up everything needed to run TFDrift-Falco in 5 minutes
+# Prepares everything `docker compose up -d` needs on a fresh clone:
+# config.yaml, .env, and self-signed TLS certs for Falco gRPC.
+#
+# Usage:
+#   ./quick-start.sh          # interactive
+#   ./quick-start.sh --yes    # non-interactive, sensible defaults
 
-VERSION="0.5.0"
+VERSION="$(tr -d '[:space:]' < VERSION 2>/dev/null || echo dev)"
 BOLD='\033[1m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
+
+NONINTERACTIVE=0
+[ "${1:-}" = "--yes" ] || [ "${1:-}" = "-y" ] && NONINTERACTIVE=1
 
 echo -e "${BOLD}🚀 TFDrift-Falco Quick Start (v${VERSION})${NC}"
 echo ""
@@ -19,7 +27,6 @@ echo ""
 # Check prerequisites
 echo -e "${BOLD}📋 Checking prerequisites...${NC}"
 
-# Check Docker
 if ! command -v docker &> /dev/null; then
     echo -e "${RED}❌ Docker is not installed${NC}"
     echo "Please install Docker: https://docs.docker.com/get-docker/"
@@ -27,7 +34,6 @@ if ! command -v docker &> /dev/null; then
 fi
 echo -e "${GREEN}✅ Docker installed${NC}"
 
-# Check Docker Compose
 if ! docker compose version &> /dev/null; then
     echo -e "${RED}❌ Docker Compose is not installed${NC}"
     echo "Please install Docker Compose: https://docs.docker.com/compose/install/"
@@ -35,188 +41,62 @@ if ! docker compose version &> /dev/null; then
 fi
 echo -e "${GREEN}✅ Docker Compose installed${NC}"
 
-# Check AWS credentials
-if [ ! -d "${HOME}/.aws" ] || [ ! -f "${HOME}/.aws/credentials" ]; then
-    echo -e "${YELLOW}⚠️  AWS credentials not found at ~/.aws/credentials${NC}"
-    echo ""
-    read -p "Do you want to configure AWS credentials now? (y/n): " configure_aws
-    if [[ "$configure_aws" == "y" || "$configure_aws" == "Y" ]]; then
-        echo ""
-        echo -e "${BOLD}Enter your AWS credentials:${NC}"
-        read -p "AWS Access Key ID: " aws_access_key_id
-        read -sp "AWS Secret Access Key: " aws_secret_access_key
-        echo ""
-        read -p "AWS Region (default: us-east-1): " aws_region
-        aws_region=${aws_region:-us-east-1}
+if ! command -v openssl &> /dev/null; then
+    echo -e "${RED}❌ openssl is not installed (needed to generate Falco gRPC certs)${NC}"
+    exit 1
+fi
+echo -e "${GREEN}✅ openssl installed${NC}"
 
-        mkdir -p "${HOME}/.aws"
-        cat > "${HOME}/.aws/credentials" <<EOF
-[default]
-aws_access_key_id = ${aws_access_key_id}
-aws_secret_access_key = ${aws_secret_access_key}
-EOF
-
-        cat > "${HOME}/.aws/config" <<EOF
-[default]
-region = ${aws_region}
-output = json
-EOF
-
-        echo -e "${GREEN}✅ AWS credentials configured${NC}"
-    else
-        echo -e "${RED}❌ AWS credentials are required to run TFDrift-Falco${NC}"
-        exit 1
-    fi
+# AWS credentials: only needed for live CloudTrail/S3 access. The default
+# compose stack (falco-simple.yaml) boots without them, so warn instead of
+# blocking.
+if [ ! -f "${HOME}/.aws/credentials" ]; then
+    echo -e "${YELLOW}⚠️  No AWS credentials at ~/.aws/credentials — the stack will boot, but live AWS drift detection needs them (aws configure).${NC}"
 else
     echo -e "${GREEN}✅ AWS credentials found${NC}"
 fi
 
 echo ""
-echo -e "${BOLD}📂 Setting up configuration files...${NC}"
+echo -e "${BOLD}🔐 Falco gRPC TLS certificates...${NC}"
+# docker-compose.yml mounts ./deployments/falco as /etc/falco/certs and
+# falco-simple.yaml expects server.key / server.crt there. These are
+# intentionally not committed (they are private keys) — generate per install.
+if [ -f deployments/falco/server.key ] && [ -f deployments/falco/server.crt ]; then
+    echo -e "${GREEN}✅ Existing certs found (deployments/falco/server.{key,crt})${NC}"
+else
+    openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
+        -keyout deployments/falco/server.key \
+        -out deployments/falco/server.crt \
+        -subj "/CN=localhost" \
+        -addext "subjectAltName=DNS:localhost,DNS:falco,IP:127.0.0.1" 2>/dev/null
+    echo -e "${GREEN}✅ Self-signed certs generated (CN=localhost, SAN: falco)${NC}"
+fi
 
-# Create directories
-mkdir -p deployments/falco
-mkdir -p rules
-mkdir -p examples/terraform
-
-# Create Falco configuration
-echo -e "${YELLOW}Creating Falco configuration...${NC}"
-cat > deployments/falco/falco.yaml <<'EOF'
-# Falco configuration for TFDrift-Falco
-watch_config_files: true
-time_format_iso_8601: true
-
-# Rules
-rules_file:
-  - /etc/falco/falco_rules.yaml
-  - /etc/falco/falco_rules.local.yaml
-  - /etc/falco/rules.d
-
-# gRPC output (required for TFDrift-Falco)
-grpc:
-  enabled: true
-  bind_address: "0.0.0.0:5060"
-  threadiness: 8
-
-grpc_output:
-  enabled: true
-
-# JSON output for CloudTrail events
-json_output: true
-json_include_output_property: true
-json_include_tags_property: true
-
-# Logging
-log_stderr: true
-log_syslog: false
-log_level: info
-
-# CloudTrail plugin configuration
-plugins:
-  - name: cloudtrail
-    library_path: libcloudtrail.so
-    init_config:
-      s3DownloadConcurrency: 64
-      sqsDelete: false
-      useAsync: true
-    open_params: ""
-
-# Load CloudTrail plugin rules
-load_plugins: [cloudtrail]
-EOF
-
-echo -e "${GREEN}✅ Falco configuration created${NC}"
-
-# Create TFDrift Falco rules
-echo -e "${YELLOW}Creating TFDrift Falco rules...${NC}"
-cat > rules/terraform_drift.yaml <<'EOF'
-# TFDrift-Falco Rules
-# These rules detect CloudTrail events that may indicate Terraform drift
-
-- rule: Terraform Managed Resource Modified
-  desc: Detect modifications to resources that should be managed by Terraform
-  condition: >
-    evt.type = aws_api_call and
-    ct.name in (
-      ModifyInstanceAttribute, ModifyDBInstance, ModifySecurityGroupRules,
-      PutBucketPolicy, PutBucketEncryption, UpdateFunctionConfiguration,
-      PutRolePolicy, UpdateAssumeRolePolicy, AttachRolePolicy,
-      AuthorizeSecurityGroupIngress, RevokeSecurityGroupIngress,
-      CreateStack, UpdateStack, DeleteStack
-    )
-  output: >
-    Potential Terraform drift detected
-    (user=%ct.user
-     event=%ct.name
-     resource=%ct.request.instanceid
-     region=%ct.region
-     source_ip=%ct.srcip
-     aws_account=%ct.account)
-  priority: WARNING
-  tags: [terraform, drift, iac]
-  source: aws_cloudtrail
-
-- rule: Critical Infrastructure Change
-  desc: Detect critical infrastructure changes that bypass IaC workflows
-  condition: >
-    evt.type = aws_api_call and
-    ct.name in (
-      TerminateInstances, DeleteDBInstance, DeleteBucket,
-      DeleteSecurityGroup, ScheduleKeyDeletion, DeleteRole,
-      DeleteStack, DeleteStateMachine
-    )
-  output: >
-    Critical infrastructure deletion detected
-    (user=%ct.user
-     event=%ct.name
-     resource=%ct.request.instanceid
-     region=%ct.region
-     aws_account=%ct.account)
-  priority: CRITICAL
-  tags: [terraform, drift, deletion, critical]
-  source: aws_cloudtrail
-
-- rule: IAM Permission Escalation
-  desc: Detect potential IAM permission escalation
-  condition: >
-    evt.type = aws_api_call and
-    ct.name in (
-      AttachUserPolicy, AttachRolePolicy, PutUserPolicy, PutRolePolicy
-    ) and
-    (ct.request.policyarn contains "AdministratorAccess" or
-     ct.request.policydocument contains "\"Effect\":\"Allow\"" and
-     ct.request.policydocument contains "\"Action\":\"*\"")
-  output: >
-    Potential IAM privilege escalation detected
-    (user=%ct.user
-     event=%ct.name
-     target_user=%ct.request.username
-     target_role=%ct.request.rolename
-     policy=%ct.request.policyarn
-     region=%ct.region)
-  priority: ALERT
-  tags: [terraform, drift, iam, security, privilege-escalation]
-  source: aws_cloudtrail
-EOF
-
-echo -e "${GREEN}✅ TFDrift rules created${NC}"
+# NOTE: Falco config (deployments/falco/falco-simple.yaml) and drift rules
+# (rules/terraform_drift.yaml) ship with the repository and are validated in
+# CI — this script no longer generates or overwrites them.
 
 # Prompt for configuration
 echo ""
 echo -e "${BOLD}🔧 TFDrift-Falco Configuration${NC}"
 echo ""
 
-# AWS Region
-read -p "AWS Region to monitor (default: us-east-1): " aws_region
-aws_region=${aws_region:-us-east-1}
+if [ "$NONINTERACTIVE" = "1" ]; then
+    aws_region="us-east-1"
+    backend_choice="2"
+    slack_webhook=""
+    echo "(--yes: region=us-east-1, backend=local, no Slack)"
+else
+    read -p "AWS Region to monitor (default: us-east-1): " aws_region
+    aws_region=${aws_region:-us-east-1}
 
-# Terraform State Backend
-echo ""
-echo "Terraform State Backend:"
-echo "  1) S3 (recommended for production)"
-echo "  2) Local file (for testing)"
-read -p "Select backend (1-2, default: 2): " backend_choice
-backend_choice=${backend_choice:-2}
+    echo ""
+    echo "Terraform State Backend:"
+    echo "  1) S3 (recommended for production)"
+    echo "  2) Local file (for testing)"
+    read -p "Select backend (1-2, default: 2): " backend_choice
+    backend_choice=${backend_choice:-2}
+fi
 
 if [ "$backend_choice" == "1" ]; then
     read -p "S3 bucket name: " s3_bucket
@@ -232,7 +112,9 @@ EOF
 else
     # Create example Terraform state
     mkdir -p examples/terraform
-    echo '{"version": 4, "terraform_version": "1.0.0", "resources": []}' > examples/terraform/terraform.tfstate
+    if [ ! -f examples/terraform/terraform.tfstate ]; then
+        echo '{"version": 4, "terraform_version": "1.0.0", "resources": []}' > examples/terraform/terraform.tfstate
+    fi
 
     state_config=$(cat <<EOF
     state:
@@ -243,8 +125,10 @@ EOF
 fi
 
 # Slack Webhook (optional)
-echo ""
-read -p "Slack webhook URL (optional, press Enter to skip): " slack_webhook
+if [ "$NONINTERACTIVE" != "1" ]; then
+    echo ""
+    read -p "Slack webhook URL (optional, press Enter to skip): " slack_webhook
+fi
 
 if [ -n "$slack_webhook" ]; then
     slack_config=$(cat <<EOF


### PR DESCRIPTION
## Summary

Condition 6 of #279 (README quickstart completes in a clean environment) — testing on a fresh clone inside a clean `golang:1.26` container found **both documented paths broken**:

| Path | Problem | Fix |
|---|---|---|
| `go run ./cmd/tfdrift --demo` | `--demo` doesn't exist (README-only fiction) | Replace with verified `--server --config config.yaml` (boots without cloud creds; health/providers APIs respond) |
| `docker compose up -d` | falco service requires TLS certs a fresh clone doesn't have | `quick-start.sh` now generates self-signed certs; README routes through it |

Also in `quick-start.sh`: stop overwriting repo-shipped `falco.yaml`/`rules/terraform_drift.yaml` (its embedded copies were the stale pre-#280 rules with nonexistent plugin fields), add `--yes` non-interactive mode, read VERSION instead of hardcoded `0.5.0`, soften the AWS-credentials hard-fail to a warning.

Version identity: `main.go` constant was still **0.4.1**; bumped to 0.13.0, `TestVersion` now pins the semver shape, and the release gate checks the binary constant as a fourth identity (tag = VERSION = CHANGELOG = binary).

## Verification
- Fresh clone + `./quick-start.sh --yes`: certs/config/.env generated, `docker compose config` valid
- Server mode on clean container: `/api/v1/health` → `{"status":"ok"}` 
- `go build` + version tests pass; `bash -n` clean; workflow YAML valid

Tracking: #279 (step 7/condition 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)