### PR TITLE
docs(site): sync docs site and website to v0.13.0; gate them at release

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -43,9 +43,22 @@ jobs:
           FILE_VERSION="$(tr -d '[:space:]' < VERSION)"
           CHANGELOG_VERSION="$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+[^]]*\]' CHANGELOG.md | tr -d '#[] ')"
           BINARY_VERSION="$(grep -m1 -oE 'version += +"[0-9]+\.[0-9]+\.[0-9]+"' cmd/tfdrift/main.go | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
-          echo "tag=v${TAG} VERSION=${FILE_VERSION} CHANGELOG=${CHANGELOG_VERSION} binary=${BINARY_VERSION}"
-          if [ "${TAG}" != "${FILE_VERSION}" ] || [ "${TAG}" != "${CHANGELOG_VERSION}" ] || [ "${TAG}" != "${BINARY_VERSION}" ]; then
-            echo "::error::Version identity mismatch: tag=v${TAG} VERSION=${FILE_VERSION} CHANGELOG=${CHANGELOG_VERSION} binary=${BINARY_VERSION}. Align them before releasing (ADR-0002)."
+          DOCS_VERSION="$(grep -m1 -oE 'project_version: +"[0-9]+\.[0-9]+\.[0-9]+"' mkdocs.yml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+          DOCS_INDEX_VERSION="$(grep -m1 -oE '\*\*Version:\*\* v[0-9]+\.[0-9]+\.[0-9]+' docs/index.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+          WEBSITE_VERSION="$(grep -m1 -oE '"v[0-9]+\.[0-9]+\.[0-9]+" label="Latest Release"' website/app/page.tsx | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+          echo "tag=v${TAG} VERSION=${FILE_VERSION} CHANGELOG=${CHANGELOG_VERSION} binary=${BINARY_VERSION} docs=${DOCS_VERSION}/${DOCS_INDEX_VERSION} website=${WEBSITE_VERSION}"
+          FAIL=0
+          for pair in "VERSION:${FILE_VERSION}" "CHANGELOG:${CHANGELOG_VERSION}" "binary:${BINARY_VERSION}" "mkdocs:${DOCS_VERSION}" "docs-index:${DOCS_INDEX_VERSION}" "website:${WEBSITE_VERSION}"; do
+            name="${pair%%:*}"; val="${pair#*:}"
+            if [ "${TAG}" != "${val}" ]; then
+              echo "::error::Version identity mismatch at ${name}: expected ${TAG}, found '${val}'. Align it before releasing (ADR-0002/0005)."
+              FAIL=1
+            fi
+          done
+          [ "${FAIL}" = "1" ] && exit 1
+          # Release notes page must exist on the docs site for this version
+          if [ ! -f "docs/release-notes/v${TAG}.md" ]; then
+            echo "::error::docs/release-notes/v${TAG}.md is missing — add the release notes page before tagging."
             exit 1
           fi
           echo "✅ Version identity consistent: v${TAG}"

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,9 @@
 
 Welcome to the official documentation for **TFDrift-Falco**, a real-time multi-cloud Terraform drift detection system with an integrated React Dashboard UI.
 
-> **Version:** v0.12.0 | **Status:** Production Ready | **Providers:** AWS (40+ services) + GCP (27+ services) + Azure
+> **Version:** v0.13.0 | **Status:** Production Ready | **Providers:** AWS (40+ services) + GCP (27+ services) + Azure
 >
-> **New in v0.12.0:** Policy-as-Code (OPA/Rego) • Drift Auto-Remediation (GitHub PR生成) • OpenTelemetry分散トレーシング | **New in v0.11.0:** クロスクラウド相関エンジン • Provider Status UI • Grafanaダッシュボード (Azure対応) | **New in v0.10.0:** E2Eテスト環境 • テストカバレッジ65%+ • CI Gate
+> **New in v0.13.0:** 公式コンテナイメージ公開（GHCR・multi-arch）• リリース整合性ゲート • E2Eテストスイート復活 • 検証済みFalcoルール — v0.10〜v0.12の機能（Policy-as-Code (OPA/Rego)・Drift Auto-Remediation・OpenTelemetry・クロスクラウド相関エンジン）を正式リリースとして統合
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,8 +1,8 @@
-# Quickstart Guide (v0.12.0)
+# Quickstart Guide (v0.13.0)
 
 Get TFDrift-Falco up and running in 5 minutes with Dashboard UI.
 
-> **New in v0.12.0:** JWT Authentication, Rate Limiting, Helm Chart, Enterprise Dashboard, Operations Runbook
+> **Tip:** 最短で試すなら、リポジトリの [README Quick Start](https://github.com/higakikeita/tfdrift-falco#quick-start)（`--server` モード / `./quick-start.sh`）から。本ガイドは Kubernetes + Helm での本格セットアップを扱います。公式イメージ: `ghcr.io/higakikeita/tfdrift-falco:v0.13.0`
 
 ---
 

--- a/docs/release-notes/v0.13.0.md
+++ b/docs/release-notes/v0.13.0.md
@@ -1,0 +1,40 @@
+# v0.13.0: Debt Settlement Release (2026-07-19)
+
+v0.9.0 以降のすべての変更を統合した「負債清算リリース」です。v0.10.0〜v0.12.0 の git タグは GitHub Release / コンテナイメージとして公開されないまま残っていたため、本リリースに一括統合しました（前進で清算 / settle forward）。
+
+**このリリースで、プロジェクト史上初めて公式コンテナイメージが公開されました。**
+
+```bash
+docker pull ghcr.io/higakikeita/tfdrift-falco:v0.13.0   # multi-arch (amd64/arm64)
+```
+
+## ハイライト
+
+### 統合された機能（v0.10〜v0.12 タグ由来）
+
+- **クロスクラウドドリフト相関エンジン** — AWS/GCP/Azure を横断してドリフトイベントを相関
+- **Policy-as-Code** — OPA/Rego によるドリフト分類（許容 / アラート / 自動修復）
+- **Drift Auto-Remediation** — 修復提案と GitHub PR の自動作成
+- **OpenTelemetry 統合** — 受信→パース→検知→通知の全フロー分散トレーシング
+- **Provider Status API** — `GET /api/v1/providers` + Grafana ダッシュボードテンプレート
+- **AWS SDK v2 移行**、品質改善（golangci-lint 警告ゼロ、UIテスト拡充）
+
+### パイプライン修復
+
+- **GHCR publish 修復** — タグビルドで不正イメージタグが生成される問題、multi-arch ビルドの QEMU 欠如、attestation の設定不備を解消
+- **E2E テストスイート復活** — ビルドタグと CI 設定の二重の問題で実行されていなかった6シナリオを再有効化（`-tags e2e`）
+- **リリース整合性ゲート** — タグ = VERSION = CHANGELOG = バイナリ定数が一致しない限りリリースは失敗する
+- **Falco ルールの検証** — cloudtrail プラグインの実フィールドに基づき書き直し、`falco -V` で検証済み
+
+### Quickstart の実働化
+
+- README の Quick Start をクリーン環境で実証済みの手順に刷新
+- `quick-start.sh`: TLS 証明書の自動生成、`--yes` 非対話モード対応
+
+### セキュリティ
+
+- コミットされていた TLS 秘密鍵と terraform plan ファイルをリポジトリから除去、`.gitignore` を強化
+
+## 詳細
+
+[GitHub Release](https://github.com/higakikeita/tfdrift-falco/releases/tag/v0.13.0) / [CHANGELOG](https://github.com/higakikeita/tfdrift-falco/blob/main/CHANGELOG.md) / [Full diff v0.8.0...v0.13.0](https://github.com/higakikeita/tfdrift-falco/compare/v0.8.0...v0.13.0)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,6 +166,7 @@ nav:
   # 7. Release Notes - Version History (newest first)
   # ==========================================
   - Release Notes:
+      - v0.13.0 (Debt Settlement, GHCR初公開): release-notes/v0.13.0.md
       - v0.12.0 (OPA/Rego, Auto-Remediation, OTel): release-notes/v0.12.0.md
       - v0.11.0 (Cross-Cloud Correlation): release-notes/v0.11.0.md
       - v0.10.0 (Testing Infrastructure): release-notes/v0.10.0.md
@@ -235,7 +236,7 @@ markdown_extensions:
 
 extra:
   # Single source of truth for version — used in docs via {{ config.extra.project_version }}
-  project_version: "0.12.0"
+  project_version: "0.13.0"
   version:
     provider: mike
     default: stable

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -42,7 +42,7 @@ export default function Home() {
           <div className="text-center space-y-8">
             <div className="inline-flex items-center space-x-2 px-4 py-2 bg-indigo-500/10 border border-indigo-500/20 rounded-full text-indigo-300 text-sm animate-pulse">
               <RocketIcon className="w-4 h-4" />
-              <span>🎉 Now Releasing v0.9.0 - Azure Full Support & Real-Time Enhancements!</span>
+              <span>🎉 Now Releasing v0.13.0 - Official Container Images on GHCR (multi-arch)!</span>
             </div>
 
             <h1 className="text-5xl md:text-7xl font-bold text-white leading-tight">
@@ -111,7 +111,7 @@ export default function Home() {
             <StatCard number="203" label="AWS Events" />
             <StatCard number="100+" label="GCP Events" />
             <StatCard number="31+" label="Total Services" />
-            <StatCard number="v0.9.0" label="Latest Release" />
+            <StatCard number="v0.13.0" label="Latest Release" />
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary

Follow-up to the v0.13.0 release: the auto-deployed doc surfaces were stale — GitHub Pages said **v0.12.0**, the Vercel landing said **v0.9.0** ("Now Releasing v0.9.0"). Deploys were automated; content honesty was not.

### Content sync
- docs site (index / quickstart / mkdocs project_version) → v0.13.0, new release-notes page for v0.13.0
- Vercel landing banner + "Latest Release" stat → v0.13.0

### Guardrail extension (ADR-0002/0005)
`verify-version-consistency` now checks **7 identities** on tag builds — tag = VERSION = CHANGELOG = binary constant = mkdocs `project_version` = docs index header = website Latest Release — and requires `docs/release-notes/v<TAG>.md` to exist. A stale docs site now **fails the release** instead of shipping quietly.

Verified locally: gate passes for 0.13.0, correctly fails a simulated 0.14.0, `mkdocs build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)