### PR TITLE
feat(ui): wire DashboardPage to real API (#289 面1, part 1)

### DIFF
--- a/ui/src/api/hooks/index.ts
+++ b/ui/src/api/hooks/index.ts
@@ -11,3 +11,4 @@ export {
   usePatternMatch
 } from './useGraphDB';
 export { useDriftSummary, useTriggerDriftDetection } from './useDiscovery';
+export { useStats } from './useStats';

--- a/ui/src/api/hooks/useStats.ts
+++ b/ui/src/api/hooks/useStats.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../client';
+import { useToastStore } from '../../stores/toastStore';
+import type { Stats } from '../types';
+
+// Hook to fetch aggregate dashboard statistics (drifts, events, severity breakdown).
+export const useStats = () => {
+  const addToast = useToastStore((state) => state.addToast);
+
+  const query = useQuery({
+    queryKey: ['stats'],
+    queryFn: async () => (await apiClient.getStats()) as Stats,
+    // Keep the dashboard live without hammering the backend
+    refetchInterval: 30000,
+  });
+
+  useEffect(() => {
+    if (query.error) {
+      const message =
+        query.error instanceof Error ? query.error.message : 'Failed to fetch stats';
+      addToast({ type: 'error', title: 'Stats Error', message });
+    }
+  }, [query.error, addToast]);
+
+  return query;
+};

--- a/ui/src/pages/DashboardPage.test.tsx
+++ b/ui/src/pages/DashboardPage.test.tsx
@@ -1,25 +1,23 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 
 vi.mock('lucide-react', () => ({
   Activity: () => <div data-testid="icon-Activity" />,
   AlertTriangle: () => <div data-testid="icon-AlertTriangle" />,
-  CheckCircle: () => <div data-testid="icon-CheckCircle" />,
+  Database: () => <div data-testid="icon-Database" />,
   Cloud: () => <div data-testid="icon-Cloud" />,
 }));
 
 vi.mock('../api/client', () => ({
   apiClient: {
-    getStats: vi.fn().mockResolvedValue({ success: true, data: {
-      graph: { total_nodes: 10, total_edges: 5 },
-      drifts: { total: 3, severity_counts: { critical: 1, high: 1, medium: 1 } },
-      events: { total: 15 },
-    }}),
-    getGraph: vi.fn().mockResolvedValue({ success: true, data: { nodes: [], edges: [] } }),
+    getStats: vi.fn(),
+    getEvents: vi.fn(),
   },
 }));
+
+import { apiClient } from '../api/client';
 
 vi.mock('../api/sse', () => ({
   sseClient: { connect: vi.fn(), disconnect: vi.fn(), on: vi.fn(), off: vi.fn() },
@@ -42,8 +40,54 @@ const renderPage = () => {
 };
 
 describe('DashboardPage', () => {
+  beforeEach(() => {
+    // apiClient methods return the unwrapped `data` (request() strips the envelope)
+    vi.mocked(apiClient.getStats).mockResolvedValue({
+      graph: { total_nodes: 10, total_edges: 5 },
+      drifts: { total: 3, severity_counts: { critical: 1, high: 1, medium: 1 } },
+      events: { total: 15 },
+    } as never);
+    vi.mocked(apiClient.getEvents).mockResolvedValue({
+      data: [
+        {
+          id: 'e1',
+          event_name: 'ModifyInstanceAttribute',
+          resource_type: 'aws_instance',
+          resource_id: 'i-123',
+          user_identity: { UserName: 'alice' },
+          severity: 'critical',
+          timestamp: '2026-07-20T00:00:00Z',
+        },
+      ],
+      page: 1,
+      limit: 8,
+      total: 1,
+      total_pages: 1,
+    } as never);
+  });
+
   it('should render without crashing', () => {
     const { container } = renderPage();
     expect(container.firstChild).toBeTruthy();
+  });
+
+  it('renders live stats from the API instead of hardcoded values', async () => {
+    renderPage();
+    // drifts.total = 3, events.total = 15, graph.total_nodes = 10, critical = 1
+    await waitFor(() => {
+      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.getByText('15')).toBeInTheDocument();
+      expect(screen.getByText('10')).toBeInTheDocument();
+    });
+    // The old placeholder must be gone
+    expect(screen.queryByText(/Coming Soon/i)).not.toBeInTheDocument();
+  });
+
+  it('renders a recent drift event with who/what', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('ModifyInstanceAttribute')).toBeInTheDocument();
+      expect(screen.getByText('alice')).toBeInTheDocument();
+    });
   });
 });

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -1,69 +1,145 @@
-import { Activity, AlertTriangle, CheckCircle, Cloud } from 'lucide-react';
+import { Activity, AlertTriangle, Database, Cloud } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { useStats } from '../api/hooks/useStats';
+import { useEvents } from '../api/hooks/useEvents';
+import type { FalcoEvent } from '../api/types';
 
 export function DashboardPage() {
+  const { data: stats, isLoading: statsLoading } = useStats();
+  const { data: eventsPage, isLoading: eventsLoading } = useEvents({
+    limit: 8,
+    sort: 'timestamp',
+    order: 'desc',
+  });
+
+  const events = eventsPage?.data ?? [];
+
+  // Safe accessors: the stats shape may be partially populated while the
+  // backend warms up, so every field falls back to a dash rather than NaN.
+  const dash = (n: number | undefined) => (typeof n === 'number' ? String(n) : '—');
+  const criticalCount =
+    stats?.drifts?.severity_counts?.critical ??
+    stats?.severity_breakdown?.critical;
+
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold text-slate-900">Dashboard</h1>
 
-      {/* Summary Cards */}
+      {/* Summary Cards — live from /api/v1/stats */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <SummaryCard
           title="Total Drift Events"
-          value="24"
-          change="+3 today"
+          value={statsLoading ? '…' : dash(stats?.drifts?.total)}
           icon={Activity}
           color="indigo"
         />
         <SummaryCard
           title="Critical"
-          value="5"
-          change="+1 today"
+          value={statsLoading ? '…' : dash(criticalCount)}
           icon={AlertTriangle}
           color="red"
         />
         <SummaryCard
-          title="Resolved"
-          value="18"
-          change="75% rate"
-          icon={CheckCircle}
-          color="green"
-        />
-        <SummaryCard
-          title="Cloud Providers"
-          value="2"
-          change="AWS, GCP"
+          title="CloudTrail Events"
+          value={statsLoading ? '…' : dash(stats?.events?.total)}
           icon={Cloud}
           color="blue"
         />
+        <SummaryCard
+          title="Tracked Resources"
+          value={statsLoading ? '…' : dash(stats?.graph?.total_nodes)}
+          icon={Database}
+          color="green"
+        />
       </div>
 
-      {/* Placeholder sections */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="bg-white rounded-xl border border-slate-200 p-6 h-72 flex items-center justify-center text-slate-400">
-          Drift Events Timeline (Coming Soon)
+      {/* Recent drift events — the who / when / what feed */}
+      <div className="bg-white rounded-xl border border-slate-200">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-slate-100">
+          <h2 className="text-sm font-semibold text-slate-700">Recent Drift Events</h2>
+          <Link to="/events" className="text-xs font-medium text-indigo-600 hover:text-indigo-700">
+            View all →
+          </Link>
         </div>
-        <div className="bg-white rounded-xl border border-slate-200 p-6 h-72 flex items-center justify-center text-slate-400">
-          Service Breakdown Chart (Coming Soon)
-        </div>
-      </div>
 
-      <div className="bg-white rounded-xl border border-slate-200 p-6 h-64 flex items-center justify-center text-slate-400">
-        Recent Drift Events Table (Coming Soon)
+        {eventsLoading ? (
+          <div className="p-6 text-sm text-slate-400">Loading events…</div>
+        ) : events.length === 0 ? (
+          <div className="p-6 text-sm text-slate-400">
+            No drift events yet. Changes made outside of Terraform/OpenTofu will appear here.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs text-slate-500 border-b border-slate-100">
+                  <th className="px-6 py-2 font-medium">Event</th>
+                  <th className="px-6 py-2 font-medium">Resource</th>
+                  <th className="px-6 py-2 font-medium">User</th>
+                  <th className="px-6 py-2 font-medium">Severity</th>
+                  <th className="px-6 py-2 font-medium">When</th>
+                </tr>
+              </thead>
+              <tbody>
+                {events.map((e) => (
+                  <EventRow key={e.id} event={e} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </div>
   );
 }
 
+function EventRow({ event }: { event: FalcoEvent }) {
+  return (
+    <tr className="border-b border-slate-50 last:border-0 hover:bg-slate-50">
+      <td className="px-6 py-3 font-medium text-slate-800">{event.event_name}</td>
+      <td className="px-6 py-3 text-slate-600">
+        {event.resource_type}
+        {event.resource_id ? <span className="text-slate-400"> · {event.resource_id}</span> : null}
+      </td>
+      <td className="px-6 py-3 text-slate-600">{event.user_identity?.UserName || '—'}</td>
+      <td className="px-6 py-3">
+        <SeverityBadge severity={event.severity} />
+      </td>
+      <td className="px-6 py-3 text-slate-500">{formatTime(event.timestamp)}</td>
+    </tr>
+  );
+}
+
+function SeverityBadge({ severity }: { severity: string }) {
+  const s = (severity || '').toLowerCase();
+  const cls: Record<string, string> = {
+    critical: 'bg-red-50 text-red-700',
+    high: 'bg-orange-50 text-orange-700',
+    medium: 'bg-amber-50 text-amber-700',
+    low: 'bg-slate-100 text-slate-600',
+  };
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${cls[s] || 'bg-slate-100 text-slate-600'}`}>
+      {severity || 'unknown'}
+    </span>
+  );
+}
+
+function formatTime(ts: string): string {
+  if (!ts) return '—';
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return ts;
+  return d.toLocaleString();
+}
+
 function SummaryCard({
   title,
   value,
-  change,
   icon: Icon,
   color,
 }: {
   title: string;
   value: string;
-  change: string;
   icon: React.ElementType;
   color: string;
 }) {
@@ -83,7 +159,6 @@ function SummaryCard({
         </div>
       </div>
       <p className="text-2xl font-bold text-slate-900">{value}</p>
-      <p className="text-xs text-slate-500 mt-1">{change}</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

First slice of #289 面1 (Web UI = flagship demo surface). The dashboard was a **張りぼて**: hardcoded `"24"/"5"/"18"/"2"` summary values and three `Coming Soon` placeholders. Now it renders live backend data.

- **`useStats` hook** over `GET /api/v1/stats` → summary cards show real drift total / critical / CloudTrail events / tracked resources
- **Recent Drift Events table** over `GET /api/v1/events` (newest 8) → the *who / when / what* feed that is the product's value proposition, with loading + empty states
- Defensive field access (partial stats render `—`, never crash)
- Tests assert live values render and `Coming Soon` is gone

## Verification
- `tsc -b` clean, **1378 UI tests pass**, `vite build` succeeds
- Shapes verified against the **running backend**: `/stats` returns the exact `Stats` shape, `/events` returns `PaginatedResponse` — no schema guessing

Follow-ups (same 面1): AnalyticsPage / TopologyPage wiring-or-gating, then 面3 Prometheus removal.

Refs #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)