### PR TITLE
fix(ui): stop infinite render loop in useSSE auto-connect

### DIFF
--- a/ui/src/api/sse.test.ts
+++ b/ui/src/api/sse.test.ts
@@ -4,6 +4,7 @@ import { useSSE, type SSEEvent } from './sse';
 
 // Mock EventSource
 class MockEventSource {
+  static instances = 0;
   url: string;
   onopen: ((event: Event) => void) | null = null;
   onmessage: ((event: MessageEvent) => void) | null = null;
@@ -14,6 +15,7 @@ class MockEventSource {
 
   constructor(url: string) {
     this.url = url;
+    MockEventSource.instances++;
   }
 }
 
@@ -27,6 +29,17 @@ describe('useSSE hook', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('auto-connects exactly once without an infinite render loop', () => {
+    // Regression: connect() used to depend on isConnecting state, so calling
+    // setIsConnecting recreated connect, re-firing the auto-connect effect
+    // (cleanup disconnect → reconnect) in an infinite loop, opening a new
+    // EventSource each pass. A stable connect must open exactly one.
+    MockEventSource.instances = 0;
+    const { unmount } = renderHook(() => useSSE({ autoConnect: true }));
+    expect(MockEventSource.instances).toBe(1);
+    unmount();
   });
 
   it('should initialize with default state', () => {

--- a/ui/src/api/sse.ts
+++ b/ui/src/api/sse.ts
@@ -45,6 +45,10 @@ export function useSSE(options: UseSSEOptions = {}): UseSSEReturn {
   const eventSource = useRef<EventSource | null>(null);
   const reconnectCount = useRef(0);
   const reconnectTimeout = useRef<NodeJS.Timeout | null>(null);
+  // Guards re-entrancy without putting isConnecting (state) in connect()'s
+  // deps — doing so recreated connect on every setIsConnecting, which made
+  // the auto-connect effect's cleanup/run cycle loop infinitely.
+  const connectingRef = useRef(false);
 
   const [isConnected, setIsConnected] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
@@ -67,6 +71,7 @@ export function useSSE(options: UseSSEOptions = {}): UseSSEReturn {
   // Schedule reconnect with exponential backoff
   const scheduleReconnect = useCallback(() => {
     if (reconnectCount.current >= reconnectAttempts) {
+      connectingRef.current = false;
       setError(new Error(`Failed to connect after ${reconnectAttempts} attempts`));
       setIsConnecting(false);
       return;
@@ -84,10 +89,11 @@ export function useSSE(options: UseSSEOptions = {}): UseSSEReturn {
   // Connect to SSE stream
   const connect = useCallback(() => {
     // Prevent multiple connections
-    if (eventSource.current || isConnecting) {
+    if (eventSource.current || connectingRef.current) {
       return;
     }
 
+    connectingRef.current = true;
     setIsConnecting(true);
     setError(null);
 
@@ -95,6 +101,7 @@ export function useSSE(options: UseSSEOptions = {}): UseSSEReturn {
       const es = new EventSource(url);
 
       es.onopen = () => {
+        connectingRef.current = false;
         setIsConnected(true);
         setIsConnecting(false);
         setError(null);
@@ -148,6 +155,7 @@ export function useSSE(options: UseSSEOptions = {}): UseSSEReturn {
 
       es.onerror = (event) => {
         logger.error('[SSE] Error:', event);
+        connectingRef.current = false;
         setIsConnected(false);
         setIsConnecting(false);
         setError(new Error('SSE connection error'));
@@ -161,11 +169,12 @@ export function useSSE(options: UseSSEOptions = {}): UseSSEReturn {
       eventSource.current = es;
     } catch (err) {
       logger.error('[SSE] Connection failed:', err);
+      connectingRef.current = false;
       setError(err instanceof Error ? err : new Error('Unknown error'));
       setIsConnecting(false);
       scheduleReconnect();
     }
-  }, [url, isConnecting, handleEvent, scheduleReconnect]);
+  }, [url, handleEvent, scheduleReconnect]);
 
   // Disconnect from SSE stream
   const disconnect = useCallback(() => {
@@ -181,6 +190,7 @@ export function useSSE(options: UseSSEOptions = {}): UseSSEReturn {
       eventSource.current = null;
     }
 
+    connectingRef.current = false;
     setIsConnected(false);
     setIsConnecting(false);
   }, [reconnectAttempts]);


### PR DESCRIPTION
## Summary

The notification panel mounts `useSSE({ autoConnect: true })` on every page. `connect()` listed `isConnecting` (state) in its `useCallback` deps, so `setIsConnecting(true)` recreated `connect`, which re-fired the auto-connect `useEffect` (deps include `connect`); its cleanup ran `disconnect()` and the effect re-ran `connect()` — an **infinite loop** flooding the console with "Maximum update depth exceeded" and churning EventSources on **all five pages**.

**Fix**: guard re-entrancy with a `connectingRef` instead of `isConnecting` state, and drop `isConnecting` from `connect()`'s deps so it's stable.

## How it was found
Running the app live and screenshotting it (visual-quality review). jsdom unit tests mocked the hooks and never exercised the real effect timing, so the loop shipped uncaught by 1339 passing tests. Added a regression test asserting `autoConnect` opens exactly one EventSource.

## Verification
- **Live**: 0 "Maximum update depth" errors on fresh mount across all pages (was ~400 per 1.5s)
- `tsc -b` clean, **1340 UI tests pass**, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)