### PR TITLE
fix(ui): stop TopologyPage infinite re-render / canvas leak (flicker)

### DIFF
--- a/ui/src/components/CytoscapeGraph.tsx
+++ b/ui/src/components/CytoscapeGraph.tsx
@@ -35,12 +35,16 @@ const CytoscapeGraphComponent = ({
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
   const [cy, setCy] = useState<Core | null>(null);
 
-  const handleNodeClick = (nodeId: string, nodeData: unknown) => {
+  // Must be stable: CytoscapeRenderer's init effect depends on this, and an
+  // unstable ref made it re-create the whole graph every render — which called
+  // onInitialized -> setCy -> re-render -> new handler -> re-create … an
+  // infinite loop that flickered the topology and leaked canvases.
+  const handleNodeClick = useCallback((nodeId: string, nodeData: unknown) => {
     setSelectedNode(nodeId);
     if (onNodeClick) {
       onNodeClick(nodeId, nodeData);
     }
-  };
+  }, [onNodeClick]);
 
   const handleCyInitialized = useCallback(() => {
     setCy(cyRef.current);


### PR DESCRIPTION
## Summary

The Topology graph **flickered and leaked canvases** — observed live against the real validation-lab (74 nodes): ~6 cytoscape instances/sec created, none destroyed, plus a flood of "Maximum update depth exceeded".

**Root cause — feedback loop in `CytoscapeGraph`:**
`handleNodeClick` was an inline function (new ref every render) passed to `CytoscapeRenderer`, whose init effect lists `onNodeClick` in its deps. Every render re-created the whole cytoscape instance; creation calls `onInitialized → setCy() → re-render → new handleNodeClick → re-create …` — unbounded.

**Fix:** `useCallback([onNodeClick])` so the init effect's deps are stable.

## Verification (live)
- Canvas churn: **0 added / 0 removed over 6s** (was 36 added / 0 removed)
- **0** new "Maximum update depth" errors (was continuous)
- Topology renders stably; `tsc` clean, CytoscapeGraph + TopologyPage tests pass (24)

Same class as the earlier SSE loop (#294) — a render-loop only reproducible by running the app, not in jsdom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)