### PR TITLE
fix(docs): claims vs reality — config schema, ghost endpoints, false auth (#319 #320 #321)

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -20,7 +20,7 @@ Format: `MAJOR.MINOR.PATCH`
 | Version | Date | Git Tag | Highlights |
 |---------|------|---------|------------|
 | 0.9.0 | 2026-03-29 | v0.9.0 | Azure FullProvider, azurerm backend, WebSocket enhancements |
-| 0.8.0 | 2026-03-22 | v0.8.0 | Enterprise Foundation (JWT, Helm, OpenAPI, Operations Runbook) |
+| 0.8.0 | 2026-03-22 | v0.8.0 | Enterprise Foundation (Helm, OpenAPI, Operations Runbook; JWT auth designed but not implemented — #319) |
 | 0.7.0 | 2026-03-22 | v0.7.0 | Dashboard UI, versioning policy |
 | 0.6.0 | 2026-03-xx | v0.6.0 | UI improvements (colors, Storybook) |
 | 0.5.0 | 2025-12-17 | v0.5.0 | Multi-Cloud GCP support |

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,5 +1,9 @@
 # TFDrift-Falco Configuration Example
-# This file demonstrates all available configuration options
+#
+# This file documents every configuration section that the loader actually
+# understands. The schema is defined by the structs in pkg/config/config.go;
+# a regression test (pkg/config/example_test.go) strict-decodes this file
+# against those structs, so any key that isn't a real field fails CI.
 
 # Cloud Provider Configuration
 providers:
@@ -11,31 +15,18 @@ providers:
       - us-west-2
       - ap-northeast-1
 
-    # CloudTrail Event Source
-    cloudtrail:
-      # SQS queue for CloudTrail events (recommended)
-      # sqs_queue: "arn:aws:sqs:us-east-1:123456789012:cloudtrail-events"
-
-      # S3 bucket for direct CloudTrail log access
-      s3_bucket: "tfdrift-cloudtrail-YOUR-AWS-ACCOUNT-ID-us-east-1"
-
     # Terraform State Backend
     state:
-      # Backend type: "local", "s3", "remote"
+      # Backend type: "local" or "s3"
       backend: "s3"
 
-      # S3 backend configuration (production-test environment)
+      # S3 backend configuration
       s3_bucket: "tfdrift-terraform-state-YOUR-AWS-ACCOUNT-ID"
       s3_key: "production-test/terraform.tfstate"
       s3_region: "us-east-1"
 
-      # Local backend configuration
+      # Local backend configuration (used when backend: "local")
       # local_path: "./terraform.tfstate"
-
-      # Remote backend (Terraform Cloud/Enterprise)
-      # remote_hostname: "app.terraform.io"
-      # remote_organization: "my-org"
-      # remote_workspace: "prod"
 
   # GCP Configuration (v0.5.0+)
   gcp:
@@ -47,21 +38,22 @@ providers:
       backend: "gcs"
       gcs_bucket: "my-terraform-state-bucket"
       gcs_prefix: "prod/terraform.tfstate"
-      # Optional: explicit credentials file
-      # credentials_file: "/path/to/service-account-key.json"
 
   # Azure Configuration (v0.7.0+)
   azure:
     enabled: false
-    subscriptions:
-      - "subscription-id-1"
-      - "subscription-id-2"
+    subscription_id: "subscription-id-1"
+    resource_group: "terraform-state-rg"
+    regions:
+      - "japaneast"
     state:
       backend: "azurerm"
-      azure_resource_group: "terraform-state-rg"
       azure_storage_account: "tfstate"
       azure_container_name: "tfstate"
-      azure_key: "prod/terraform.tfstate"
+      azure_blob_name: "prod/terraform.tfstate"
+      # Optional credentials (otherwise the default Azure credential chain is used)
+      # azure_access_key: "..."
+      # azure_sas_token: "..."
 
 # Falco Integration (Required for TFDrift-Falco)
 # You must have Falco 0.35+ installed with:
@@ -72,35 +64,12 @@ falco:
 
   # Falco gRPC server configuration
   hostname: "localhost"  # Falco gRPC server hostname
-  port: 5060              # Falco gRPC server port (default: 5060)
+  port: 5060             # Falco gRPC server port (default: 5060)
 
   # Optional: mTLS client certificates (if Falco gRPC requires authentication)
   # cert_file: "/path/to/client-cert.pem"
   # key_file: "/path/to/client-key.pem"
   # ca_root_file: "/path/to/ca-root.pem"
-
-# API Server Configuration (v0.8.0+)
-api:
-  # Authentication
-  auth:
-    enabled: false  # Set to true to require authentication
-    jwt_secret: "CHANGE-ME-to-a-secure-random-string-at-least-32-chars"
-    jwt_issuer: "tfdrift-falco"
-    jwt_expiry: "24h"  # Token expiration (Go duration: 1h, 24h, 168h)
-
-    # Pre-configured API keys (optional)
-    # api_keys:
-    #   - name: "ci-pipeline"
-    #     key: "tfd_your-api-key-here"
-    #     scopes: ["read"]
-    #     created_at: "2026-03-22T00:00:00Z"
-
-  # Rate Limiting
-  rate_limit:
-    enabled: false  # Set to true to enable rate limiting
-    requests_per_minute: 60  # Max requests per minute per client
-    burst_size: 10  # Max burst size
-    cleanup_interval: "5m"  # How often to clean up expired entries
 
 # Drift Detection Rules
 drift_rules:
@@ -208,14 +177,6 @@ drift_rules:
       - "source_ranges"
     severity: "critical"
 
-  - name: "Cloud Storage Bucket Security"
-    resource_types:
-      - "google_storage_bucket"
-    watched_attributes:
-      - "encryption"
-      - "public_access_prevention"
-    severity: "critical"
-
 # Notification Channels
 notifications:
   # Slack Integration
@@ -223,9 +184,6 @@ notifications:
     enabled: true
     webhook_url: "https://hooks.slack.com/services/YOUR/WEBHOOK/URL"
     channel: "#security-alerts"
-
-    # Optional: Minimum severity to send to Slack
-    # min_severity: "medium"  # critical, high, medium, low
 
   # Discord Integration
   discord:
@@ -241,39 +199,9 @@ notifications:
   webhook:
     enabled: false
     url: "https://your-siem.example.com/webhook"
-    method: "POST"  # POST, PUT
     headers:
       Authorization: "Bearer YOUR_TOKEN"
       Content-Type: "application/json"
-
-    # Optional: Custom payload template (Go template syntax)
-    # payload_template: |
-    #   {
-    #     "alert_type": "terraform_drift",
-    #     "severity": "{{ .Severity }}",
-    #     "resource": "{{ .ResourceType }}.{{ .ResourceName }}",
-    #     "user": "{{ .UserIdentity.UserName }}"
-    #   }
-
-  # Email Notifications (future)
-  # email:
-  #   enabled: false
-  #   smtp_host: "smtp.gmail.com"
-  #   smtp_port: 587
-  #   from: "tfdrift@example.com"
-  #   to:
-  #     - "sre-team@example.com"
-  #     - "security-team@example.com"
-
-  # PagerDuty Integration (future)
-  # pagerduty:
-  #   enabled: false
-  #   integration_key: "YOUR_INTEGRATION_KEY"
-  #   severity_mapping:
-  #     critical: "critical"
-  #     high: "error"
-  #     medium: "warning"
-  #     low: "info"
 
 # Logging Configuration
 logging:
@@ -282,12 +210,6 @@ logging:
 
   # Log format: json, text
   format: "json"
-
-  # Log output: stdout, stderr, file
-  output: "stdout"
-
-  # Optional: Log file path (when output is "file")
-  # file: "/var/log/tfdrift-falco.log"
 
 # Automatic import of unmanaged resources
 auto_import:
@@ -305,42 +227,42 @@ auto_import:
   # Where to write generated .tf resource blocks
   output_dir: "./imported"
 
+  # Restrict which resource types may be auto-imported (empty = all allowed)
+  allowed_resources:
+    - "aws_security_group"
+    - "aws_instance"
+
   # Require manual approval before importing
   require_approval: true
 
-# Advanced Options
-advanced:
-  # State refresh interval (how often to reload Terraform state)
-  state_refresh_interval: "5m"
+# OpenTelemetry (traces + metrics export). Disabled by default.
+telemetry:
+  enabled: false
+  service_name: "tfdrift-falco"
+  service_version: ""
+  environment: "production"
+  traces_endpoint: "localhost:4317"
+  metrics_endpoint: "localhost:4317"
+  sampling_ratio: 1.0
+  insecure: true
+  # attributes:
+  #   team: "platform-security"
 
-  # Event processing workers
-  workers: 4
+# Remediation (open pull requests that fix drift). Requires github below.
+remediation:
+  enabled: false
+  create_prs: false
+  dry_run: true
 
-  # Event buffer size
-  event_buffer_size: 100
+# GitHub integration (used by remediation to open PRs)
+github:
+  enabled: false
+  owner: "your-org"
+  repo: "your-infra-repo"
+  branch: "main"
+  # token: set via TFDRIFT_GITHUB_TOKEN env var instead of committing it here
 
-  # Rate limiting (alerts per minute per resource)
-  rate_limit:
-    enabled: true
-    max_alerts_per_minute: 5
-
-  # Deduplication window (suppress duplicate alerts within this time)
-  deduplication_window: "5m"
-
-  # Ignored users (don't alert on changes by these users)
-  ignored_users:
-    - "terraform-automation-user"
-    - "arn:aws:sts::123456789012:assumed-role/TerraformRole/*"
-
-  # Ignored resources (don't monitor these resources)
-  ignored_resources:
-    - "aws_instance.bastion-temp-*"
-    - "aws_s3_bucket.test-*"
-
-  # Maintenance windows (disable alerts during these times)
-  maintenance_windows:
-    - name: "Weekly Deployment"
-      days: ["Sunday"]
-      start_time: "02:00"
-      end_time: "06:00"
-      timezone: "America/New_York"
+# Policy engine (evaluate drift against .rego policies)
+policy:
+  enabled: false
+  policy_dir: "./policies"

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -303,7 +303,7 @@ make status
 
 # 期待される出力:
 # NAME                    STATUS              PORTS
-# tfdrift-falco-app       Up 30 seconds       0.0.0.0:9090->9090/tcp
+# tfdrift-falco-app       Up 30 seconds       0.0.0.0:8080->8080/tcp
 # tfdrift-falco-falco     Up 30 seconds       0.0.0.0:5060->5060/tcp
 ```
 

--- a/docs/PRODUCTION_READINESS.md
+++ b/docs/PRODUCTION_READINESS.md
@@ -480,10 +480,12 @@
   - アラートが発生した際の対応手順を文書化
   - エスカレーションフロー
 
-- [ ] **メトリクス収集**
+- [ ] **メトリクス収集（OpenTelemetry）**
   ```bash
-  # Prometheus メトリクスの確認
-  curl http://localhost:9090/metrics | grep tfdrift
+  # ヘルスチェック（API サーバは 8080）
+  curl http://localhost:8080/health
+  # メトリクス/トレースは telemetry.enabled: true 時に OTLP で push エクスポートされる
+  # （スクレイプ型 /metrics エンドポイントは無い）。OTLP コレクタ側で確認する。
   ```
 
 ---

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -41,16 +41,6 @@ tags:
     description: Authentication and API key management
 
 components:
-  securitySchemes:
-    BearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
-    ApiKeyAuth:
-      type: apiKey
-      in: header
-      name: X-API-Key
-
   schemas:
     APIResponse:
       type: object
@@ -298,10 +288,6 @@ components:
         end_filter:
           type: object
 
-security:
-  - BearerAuth: []
-  - ApiKeyAuth: []
-
 paths:
   /health:
     get:
@@ -328,19 +314,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/HealthResponse"
-
-  /api/v1/version:
-    get:
-      tags: [Config]
-      summary: Get API version
-      security: []
-      responses:
-        "200":
-          description: Version information
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIResponse"
 
   /api/v1/events:
     get:
@@ -474,30 +447,6 @@ paths:
       responses:
         "200":
           description: System statistics including graph, drifts, events, and severity breakdown
-
-  /api/v1/analytics/summary:
-    get:
-      tags: [Analytics]
-      summary: Get analytics summary
-      responses:
-        "200":
-          description: Summary with total events, severity counts, providers, resolved rate
-
-  /api/v1/analytics/timeline:
-    get:
-      tags: [Analytics]
-      summary: Get event timeline (7-day)
-      responses:
-        "200":
-          description: Array of daily event counts by provider
-
-  /api/v1/analytics/breakdown:
-    get:
-      tags: [Analytics]
-      summary: Get event breakdown
-      responses:
-        "200":
-          description: Breakdown by provider, service, and severity
 
   /api/v1/graph:
     get:
@@ -757,30 +706,6 @@ paths:
         "200":
           description: Drift summary with counts and breakdown by type
 
-  /api/v1/config:
-    get:
-      tags: [Config]
-      summary: Get current configuration (safe subset)
-      responses:
-        "200":
-          description: Provider and notification configuration
-
-  /api/v1/config/webhooks/test:
-    post:
-      tags: [Config]
-      summary: Test webhook URL
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/WebhookTestRequest"
-      responses:
-        "200":
-          description: Webhook test result
-        "400":
-          description: Invalid URL
-
   /api/v1/stream:
     get:
       tags: [Events]
@@ -803,84 +728,3 @@ paths:
         "101":
           description: WebSocket upgrade
 
-  /api/v1/auth/token:
-    post:
-      tags: [Auth]
-      summary: Generate JWT token
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/TokenRequest"
-      responses:
-        "200":
-          description: JWT token
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/APIResponse"
-                  - properties:
-                      data:
-                        $ref: "#/components/schemas/TokenResponse"
-        "400":
-          description: Invalid request
-
-  /api/v1/auth/api-keys:
-    get:
-      tags: [Auth]
-      summary: List API keys (masked)
-      responses:
-        "200":
-          description: List of API keys with masked values
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/APIResponse"
-                  - properties:
-                      data:
-                        type: array
-                        items:
-                          $ref: "#/components/schemas/APIKeyInfo"
-    post:
-      tags: [Auth]
-      summary: Create API key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateAPIKeyRequest"
-      responses:
-        "201":
-          description: Created API key (key shown only once)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/APIResponse"
-                  - properties:
-                      data:
-                        $ref: "#/components/schemas/CreateAPIKeyResponse"
-        "400":
-          description: Invalid request
-    delete:
-      tags: [Auth]
-      summary: Revoke API key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [name]
-              properties:
-                name:
-                  type: string
-      responses:
-        "200":
-          description: API key revoked
-        "404":
-          description: API key not found

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -217,7 +217,7 @@ List all resources in Terraform state.
 
 Retrieve detailed information about a specific resource.
 
-**Endpoint:** `GET /api/v1/state/resources/:address`
+**Endpoint:** `GET /api/v1/state/resource/{id}`
 
 **Response:**
 ```json

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -578,111 +578,52 @@ resource "aws_s3_bucket_public_access_block" "terraform_state" {
 
 ## Monitoring & Observability
 
-### Prometheus Metrics
+### Metrics (OpenTelemetry)
 
-TFDrift-Falcoは以下のメトリクスを公開します（`/metrics` エンドポイント）:
-
-```prometheus
-# 検知したドリフトイベント数
-tfdrift_events_total{severity="critical"} 5
-tfdrift_events_total{severity="high"} 23
-
-# リソースタイプ別イベント数
-tfdrift_events_by_type{type="aws_instance"} 12
-tfdrift_events_by_type{type="aws_iam_role"} 8
-
-# 検知レイテンシー（秒）
-tfdrift_detection_latency_seconds{quantile="0.5"} 0.8
-tfdrift_detection_latency_seconds{quantile="0.95"} 2.3
-tfdrift_detection_latency_seconds{quantile="0.99"} 5.1
-
-# Falco接続状態
-tfdrift_falco_connected 1
-
-# Terraform State同期時刻（UnixTimestamp）
-tfdrift_state_last_sync_timestamp 1705312345
-```
-
-### Grafana Alerting
-
-**アラートルール例**:
+TFDrift-Falco はスクレイプ型の `/metrics` エンドポイントを公開しません。メトリクスとトレースは
+`telemetry.enabled: true` のときに **OpenTelemetry (OTLP)** で push エクスポートされます。
+OTLP コレクタ（例: OpenTelemetry Collector）を用意し、そこから Prometheus / Grafana など任意の
+バックエンドへ転送してください。
 
 ```yaml
-# grafana-alerts.yaml
-groups:
-  - name: tfdrift-alerts
-    interval: 1m
-    rules:
-      # Criticalドリフトが発生したら即座に通知
-      - alert: CriticalDriftDetected
-        expr: increase(tfdrift_events_total{severity="critical"}[5m]) > 0
-        for: 0m
-        labels:
-          severity: critical
-        annotations:
-          summary: "Critical drift detected in {{ $labels.environment }}"
-          description: "{{ $value }} critical drift events detected in the last 5 minutes"
-
-      # 検知レイテンシーが10秒を超えたら警告
-      - alert: HighDetectionLatency
-        expr: tfdrift_detection_latency_seconds{quantile="0.95"} > 10
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "High drift detection latency"
-          description: "P95 latency is {{ $value }}s (threshold: 10s)"
-
-      # Falco接続が切れたら即座にアラート
-      - alert: FalcoConnectionLost
-        expr: tfdrift_falco_connected == 0
-        for: 1m
-        labels:
-          severity: critical
-        annotations:
-          summary: "Lost connection to Falco"
-          description: "TFDrift-Falco cannot connect to Falco gRPC endpoint"
-
-      # State同期が30分以上行われていない場合
-      - alert: TerraformStateStale
-        expr: (time() - tfdrift_state_last_sync_timestamp) > 1800
-        for: 5m
-        labels:
-          severity: warning
-        annotations:
-          summary: "Terraform state not synced for 30+ minutes"
-          description: "Last sync: {{ $value | humanizeDuration }}"
+telemetry:
+  enabled: true
+  traces_endpoint: "otel-collector:4317"
+  metrics_endpoint: "otel-collector:4317"
+  insecure: true
 ```
+
+### Alerting
+
+ドリフトの通知は組み込みの通知チャネル（Slack / Discord / 汎用 Webhook）で行います
+（`notifications:` セクション参照）。メトリクスベースのアラートは、上記 OTLP エクスポート先の
+観測バックエンド側で設定してください。
 
 ### Health Checks
 
-**Kubernetes Liveness & Readiness Probes**:
+API サーバは `GET /health`（および `/api/v1/health`）を公開します。Kubernetes の
+liveness / readiness は、どちらもこのエンドポイントに向けてください（専用の `/healthz`・`/ready`
+は現状ありません）。
 
 ```yaml
 livenessProbe:
   httpGet:
-    path: /healthz
+    path: /health
     port: 8080
   initialDelaySeconds: 30
   periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 3
 
 readinessProbe:
   httpGet:
-    path: /ready
+    path: /health
     port: 8080
   initialDelaySeconds: 10
   periodSeconds: 5
-  timeoutSeconds: 3
-  failureThreshold: 2
 ```
 
 **ヘルスチェックエンドポイント**:
 
-- `GET /healthz` - 基本的なヘルスチェック（プロセスが生きているか）
-- `GET /ready` - 準備状態チェック（Falco接続、State読み込み完了）
-- `GET /metrics` - Prometheusメトリクス
+- `GET /health` - ヘルスチェック（プロセス稼働＋基本状態）
 
 ---
 

--- a/docs/deploy/gke.md
+++ b/docs/deploy/gke.md
@@ -218,11 +218,10 @@ podDisruptionBudget:
   enabled: true
   minAvailable: 2
 
-# Pod annotations for monitoring
-podAnnotations:
-  prometheus.io/scrape: "true"
-  prometheus.io/port: "8080"
-  prometheus.io/path: "/metrics"
+# Pod annotations (optional). TFDrift-Falco has no scrape-style /metrics
+# endpoint; metrics/traces are pushed via OpenTelemetry (OTLP) when
+# telemetry.enabled: true. Point telemetry at your OTLP collector instead.
+podAnnotations: {}
 
 # Service configuration
 service:
@@ -454,9 +453,10 @@ gcloud compute backend-services update tfdrift-falco-backend \
 ### Enable Cloud Monitoring
 
 ```bash
-# Cloud Monitoring is automatically enabled with GKE
-# Verify Prometheus metrics are scraped
-kubectl get servicemonitor -n tfdrift-falco
+# Cloud Monitoring is automatically enabled with GKE.
+# TFDrift-Falco exports metrics/traces via OpenTelemetry (OTLP) when
+# telemetry.enabled: true — send them to an OTLP collector, not a scrape target.
+kubectl get pods -n tfdrift-falco
 ```
 
 ### Create Monitoring Dashboard

--- a/pkg/api/handlers/openapi.yaml
+++ b/pkg/api/handlers/openapi.yaml
@@ -41,16 +41,6 @@ tags:
     description: Authentication and API key management
 
 components:
-  securitySchemes:
-    BearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
-    ApiKeyAuth:
-      type: apiKey
-      in: header
-      name: X-API-Key
-
   schemas:
     APIResponse:
       type: object
@@ -298,10 +288,6 @@ components:
         end_filter:
           type: object
 
-security:
-  - BearerAuth: []
-  - ApiKeyAuth: []
-
 paths:
   /health:
     get:
@@ -328,19 +314,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/HealthResponse"
-
-  /api/v1/version:
-    get:
-      tags: [Config]
-      summary: Get API version
-      security: []
-      responses:
-        "200":
-          description: Version information
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/APIResponse"
 
   /api/v1/events:
     get:
@@ -474,30 +447,6 @@ paths:
       responses:
         "200":
           description: System statistics including graph, drifts, events, and severity breakdown
-
-  /api/v1/analytics/summary:
-    get:
-      tags: [Analytics]
-      summary: Get analytics summary
-      responses:
-        "200":
-          description: Summary with total events, severity counts, providers, resolved rate
-
-  /api/v1/analytics/timeline:
-    get:
-      tags: [Analytics]
-      summary: Get event timeline (7-day)
-      responses:
-        "200":
-          description: Array of daily event counts by provider
-
-  /api/v1/analytics/breakdown:
-    get:
-      tags: [Analytics]
-      summary: Get event breakdown
-      responses:
-        "200":
-          description: Breakdown by provider, service, and severity
 
   /api/v1/graph:
     get:
@@ -757,30 +706,6 @@ paths:
         "200":
           description: Drift summary with counts and breakdown by type
 
-  /api/v1/config:
-    get:
-      tags: [Config]
-      summary: Get current configuration (safe subset)
-      responses:
-        "200":
-          description: Provider and notification configuration
-
-  /api/v1/config/webhooks/test:
-    post:
-      tags: [Config]
-      summary: Test webhook URL
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/WebhookTestRequest"
-      responses:
-        "200":
-          description: Webhook test result
-        "400":
-          description: Invalid URL
-
   /api/v1/stream:
     get:
       tags: [Events]
@@ -803,84 +728,3 @@ paths:
         "101":
           description: WebSocket upgrade
 
-  /api/v1/auth/token:
-    post:
-      tags: [Auth]
-      summary: Generate JWT token
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/TokenRequest"
-      responses:
-        "200":
-          description: JWT token
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/APIResponse"
-                  - properties:
-                      data:
-                        $ref: "#/components/schemas/TokenResponse"
-        "400":
-          description: Invalid request
-
-  /api/v1/auth/api-keys:
-    get:
-      tags: [Auth]
-      summary: List API keys (masked)
-      responses:
-        "200":
-          description: List of API keys with masked values
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/APIResponse"
-                  - properties:
-                      data:
-                        type: array
-                        items:
-                          $ref: "#/components/schemas/APIKeyInfo"
-    post:
-      tags: [Auth]
-      summary: Create API key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateAPIKeyRequest"
-      responses:
-        "201":
-          description: Created API key (key shown only once)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/APIResponse"
-                  - properties:
-                      data:
-                        $ref: "#/components/schemas/CreateAPIKeyResponse"
-        "400":
-          description: Invalid request
-    delete:
-      tags: [Auth]
-      summary: Revoke API key
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [name]
-              properties:
-                name:
-                  type: string
-      responses:
-        "200":
-          description: API key revoked
-        "404":
-          description: API key not found

--- a/pkg/config/example_test.go
+++ b/pkg/config/example_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestConfigExample_NoPhantomKeys guards config.yaml.example against
+// "claim != reality" drift: every key in the shipped example must map to a
+// real field on the Config struct. yaml.v3's KnownFields(true) fails the
+// decode on any unknown key, so a phantom block (e.g. a documented option the
+// loader silently ignores) breaks this test instead of misleading a user.
+//
+// Regression for #320: the example previously documented api:, advanced:,
+// providers.aws.cloudtrail:, azure subscriptions/azure_key, webhook.method,
+// logging.output and other keys that no struct field backed.
+func TestConfigExample_NoPhantomKeys(t *testing.T) {
+	path := filepath.Join("..", "..", "config.yaml.example")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "config.yaml.example must exist at repo root")
+
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	var cfg Config
+	if err := dec.Decode(&cfg); err != nil {
+		t.Fatalf("config.yaml.example contains keys that no Config field backs "+
+			"(phantom/undocumented options mislead users). Fix the example or add "+
+			"the field: %v", err)
+	}
+}
+
+// TestConfigExample_RealSectionsPresent asserts the example actually exercises
+// the sections that exist in the struct, so the file stays a useful reference
+// and the header's "documents every section" claim is honest.
+func TestConfigExample_RealSectionsPresent(t *testing.T) {
+	path := filepath.Join("..", "..", "config.yaml.example")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+
+	require.True(t, cfg.Providers.AWS.Enabled, "aws provider should be shown enabled")
+	require.NotEmpty(t, cfg.Providers.AWS.Regions, "aws regions should be present")
+	require.True(t, cfg.Falco.Enabled, "falco section should be present and enabled")
+	require.NotEmpty(t, cfg.DriftRules, "drift_rules should be present")
+	require.NotEmpty(t, cfg.Notifications.Slack.WebhookURL, "notifications.slack should be present")
+	require.Equal(t, "terraform", cfg.AutoImport.Tool, "auto_import section should be present")
+
+	// Sections that were missing from the old example (#320): telemetry,
+	// remediation, github, policy. They must at least be representable.
+	require.Equal(t, "tfdrift-falco", cfg.Telemetry.ServiceName, "telemetry section should be documented")
+	require.False(t, cfg.Remediation.Enabled, "remediation section should be documented")
+	require.Equal(t, "main", cfg.GitHub.Branch, "github section should be documented")
+	require.Equal(t, "./policies", cfg.Policy.PolicyDir, "policy section should be documented")
+}


### PR DESCRIPTION
Removes "claim ≠ reality" documentation debt so a first-time reader/evaluator isn't misled. Diagnosis: ADR-0012.

## Changes
- **#320 config schema.** `config.yaml.example` documented keys no struct field backs (`api:`, `advanced:`, `providers.aws.cloudtrail:`, Azure `subscriptions`/`azure_key`, `webhook.method`, `logging.output`, …) — the loader silently ignored them, so users configured no-ops. Regenerated strictly from the real config struct; added the missing real sections (telemetry/remediation/github/policy). New `pkg/config/example_test.go` strict-decodes the example (yaml `KnownFields`) so any future phantom key fails CI.
- **#319 false auth / "Production Ready".** Removed the fictional `--demo` from README.ja, and the JWT/API-Key "Production Ready" claims that no code backs, across README(.ja), docs/index, ADR-004, PROJECT_ROADMAP, VERSIONING.
- **#321 ghost API surface.** Pruned 8 non-existent OpenAPI paths (`/version`, `/analytics/*`, `/config*`, `/auth/*`) and the unimplemented auth securitySchemes; removed `/metrics` + `:9090` (Prometheus was removed) from best-practices / PRODUCTION_READINESS / GETTING_STARTED / gke; fixed the `/state/resource/{id}` route in rest-api.md.

## Tests
`go build ./...` clean; `go test ./pkg/config/` green (new phantom-key guard); OpenAPI YAML validated.

## Merge order
Merge LAST (after security + core-hardening). Overlaps README / README.ja / docs/index / ADR-004 / PROJECT_ROADMAP with the other two PRs — will need a rebase onto updated main. Note: #319's auth-claim edits are superseded by the more complete security-branch versions, so expect to take those on conflict. Remaining doc items (#322 version banners + release gate #317, #323 dead links/Grafana) are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)