### PR TITLE
feat(cli): add 'tfdrift scan' one-shot reconcile (Fixes #334)

### DIFF
--- a/cmd/tfdrift/main.go
+++ b/cmd/tfdrift/main.go
@@ -59,8 +59,9 @@ and Terraform/OpenTofu state comparison.`,
 	rootCmd.Flags().StringVar(&statePathOverride, "state-path", "", "Terraform state file path (e.g., --state-path ./terraform.tfstate)")
 	rootCmd.Flags().StringVar(&backendTypeOverride, "backend", "", "Backend type: local or s3 (e.g., --backend local)")
 
-	// Add approval subcommands
+	// Add subcommands
 	rootCmd.AddCommand(newApprovalCmd())
+	rootCmd.AddCommand(newScanCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/tfdrift/scan.go
+++ b/cmd/tfdrift/scan.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/keitahigaki/tfdrift-falco/pkg/aws"
+	"github.com/keitahigaki/tfdrift-falco/pkg/config"
+	"github.com/keitahigaki/tfdrift-falco/pkg/terraform"
+	"github.com/keitahigaki/tfdrift-falco/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+// maxDriftExitCode caps the drift-count exit code well below the shell-reserved
+// range (126+) so "N drifts" stays a plain, unambiguous status.
+const maxDriftExitCode = 250
+
+// newScanCmd builds the `tfdrift scan` subcommand: a one-shot, read-only
+// reconcile between Terraform state and live cloud state. No Falco, no
+// CloudTrail — deterministic and CI-friendly (#334, ADR-0014).
+func newScanCmd() *cobra.Command {
+	var (
+		scanConfig  string
+		scanRegions []string
+		scanOutput  string
+		failOnDrift bool
+	)
+	cmd := &cobra.Command{
+		Use:   "scan",
+		Short: "One-shot reconcile: compare live cloud state against Terraform state and report drift",
+		Long: `scan performs a single read-only reconcile between your Terraform state and the
+actual cloud resources (AWS), then reports unmanaged / missing / modified
+resources and exits with a code reflecting the result.
+
+Unlike the daemon it needs no Falco and no CloudTrail — only read access to the
+Terraform state and the cloud provider. It is deterministic and suited to CI
+(nightly drift gate) and to answering "right now, does reality match my code?".
+
+Exit code: 0 = no drift; otherwise the number of drifted resources (capped at
+250). Use --fail-on-drift=false to always exit 0 and only report.`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			code, err := runScan(scanConfig, scanRegions, scanOutput, failOnDrift)
+			if err != nil {
+				return err
+			}
+			if code != 0 {
+				os.Exit(code)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&scanConfig, "config", "", "config file (default is config.yaml)")
+	cmd.Flags().StringSliceVar(&scanRegions, "region", nil, "AWS region(s) to scan; overrides config (e.g. --region us-east-1,ap-northeast-1)")
+	cmd.Flags().StringVar(&scanOutput, "output", "human", "output mode: human or json")
+	cmd.Flags().BoolVar(&failOnDrift, "fail-on-drift", true, "exit non-zero (drift count) when drift is found")
+	return cmd
+}
+
+// runScan executes the reconcile and returns the process exit code.
+func runScan(cfgPath string, regionsOverride []string, output string, failOnDrift bool) (int, error) {
+	if cfgPath == "" {
+		cfgPath = "config.yaml"
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		return 0, fmt.Errorf("load config %q: %w", cfgPath, err)
+	}
+	if !cfg.Providers.AWS.Enabled {
+		return 0, fmt.Errorf("scan currently supports AWS only; enable providers.aws in %s", cfgPath)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	sm, err := terraform.NewStateManager(cfg.Providers.AWS.State)
+	if err != nil {
+		return 0, fmt.Errorf("create state manager: %w", err)
+	}
+	if err := sm.Load(ctx); err != nil {
+		return 0, fmt.Errorf("load terraform state: %w", err)
+	}
+	tfResources := sm.GetAllResources()
+
+	regions := regionsOverride
+	if len(regions) == 0 {
+		regions = cfg.Providers.AWS.Regions
+	}
+	if len(regions) == 0 {
+		regions = []string{"us-east-1"}
+	}
+
+	// Discover across all regions first, then compare ONCE: comparing per
+	// region would flag a resource as "missing" whenever it lives in another
+	// region. Dedup by ID so a global resource (IAM/S3) seen in several regions
+	// isn't counted as multiple unmanaged resources.
+	var allAWS []*types.DiscoveredResource
+	seen := make(map[string]bool)
+	for _, region := range regions {
+		dc, err := aws.NewDiscoveryClient(ctx, region)
+		if err != nil {
+			return 0, fmt.Errorf("create discovery client (%s): %w", region, err)
+		}
+		res, err := dc.DiscoverAll(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("discover resources (%s): %w", region, err)
+		}
+		for _, r := range res {
+			if r != nil && !seen[r.ID] {
+				seen[r.ID] = true
+				allAWS = append(allAWS, r)
+			}
+		}
+	}
+
+	drift := aws.CompareStateWithActual(tfResources, allAWS)
+
+	report := renderDriftReport(drift, output, len(tfResources), len(allAWS), regions)
+	fmt.Println(report)
+
+	return exitCodeForDrift(driftTotal(drift), failOnDrift), nil
+}
+
+// driftTotal is the number of drifted resources across all categories.
+func driftTotal(d *types.DriftResult) int {
+	if d == nil {
+		return 0
+	}
+	return len(d.UnmanagedResources) + len(d.MissingResources) + len(d.ModifiedResources)
+}
+
+// exitCodeForDrift maps a drift count to a process exit code (0 = clean).
+func exitCodeForDrift(total int, failOnDrift bool) int {
+	if total == 0 || !failOnDrift {
+		return 0
+	}
+	if total > maxDriftExitCode {
+		return maxDriftExitCode
+	}
+	return total
+}
+
+// renderDriftReport formats the reconcile result. Pure (no IO) so it is unit
+// tested without cloud access.
+func renderDriftReport(d *types.DriftResult, output string, tfCount, awsCount int, regions []string) string {
+	if d == nil {
+		d = &types.DriftResult{}
+	}
+	if output == "json" {
+		payload := map[string]interface{}{
+			"timestamp": time.Now().UTC().Format(time.RFC3339),
+			"regions":   regions,
+			"summary": map[string]int{
+				"terraform_resources": tfCount,
+				"cloud_resources":     awsCount,
+				"unmanaged":           len(d.UnmanagedResources),
+				"missing":             len(d.MissingResources),
+				"modified":            len(d.ModifiedResources),
+				"total_drift":         driftTotal(d),
+			},
+			"drift": d,
+		}
+		b, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			return fmt.Sprintf(`{"error":%q}`, err.Error())
+		}
+		return string(b)
+	}
+
+	var b strings.Builder
+	total := driftTotal(d)
+	fmt.Fprintf(&b, "TFDrift scan — regions: %s\n", strings.Join(regions, ", "))
+	fmt.Fprintf(&b, "  terraform resources: %d | cloud resources: %d\n", tfCount, awsCount)
+	if total == 0 {
+		b.WriteString("\n✅ No drift: live cloud state matches Terraform state.\n")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "\n⚠️  Drift detected: %d resource(s) — unmanaged=%d missing=%d modified=%d\n",
+		total, len(d.UnmanagedResources), len(d.MissingResources), len(d.ModifiedResources))
+
+	if len(d.UnmanagedResources) > 0 {
+		b.WriteString("\nUnmanaged (in cloud, not in Terraform):\n")
+		for _, r := range d.UnmanagedResources {
+			fmt.Fprintf(&b, "  + %s %s (%s)\n", r.Type, r.ID, r.Region)
+		}
+	}
+	if len(d.MissingResources) > 0 {
+		b.WriteString("\nMissing (in Terraform, not in cloud):\n")
+		for _, r := range d.MissingResources {
+			fmt.Fprintf(&b, "  - %s.%s (%s)\n", r.Type, r.Name, r.ID)
+		}
+	}
+	if len(d.ModifiedResources) > 0 {
+		b.WriteString("\nModified (attribute differences):\n")
+		for _, r := range d.ModifiedResources {
+			fmt.Fprintf(&b, "  ~ %s %s\n", r.ResourceType, r.ResourceID)
+			for _, f := range r.Differences {
+				fmt.Fprintf(&b, "      %s: terraform=%v actual=%v\n", f.Field, f.TerraformValue, f.ActualValue)
+			}
+		}
+	}
+	return b.String()
+}

--- a/cmd/tfdrift/scan.go
+++ b/cmd/tfdrift/scan.go
@@ -65,7 +65,7 @@ func runScan(cfgPath string, regionsOverride []string, output string, failOnDrif
 	if cfgPath == "" {
 		cfgPath = "config.yaml"
 	}
-	cfg, err := config.Load(cfgPath)
+	cfg, err := config.LoadForScan(cfgPath)
 	if err != nil {
 		return 0, fmt.Errorf("load config %q: %w", cfgPath, err)
 	}

--- a/cmd/tfdrift/scan_test.go
+++ b/cmd/tfdrift/scan_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/keitahigaki/tfdrift-falco/pkg/types"
+)
+
+func sampleDrift() *types.DriftResult {
+	return &types.DriftResult{
+		Provider: "aws",
+		UnmanagedResources: []*types.DiscoveredResource{
+			{Type: "aws_security_group", ID: "sg-123", Region: "us-east-1"},
+		},
+		MissingResources: []*types.TerraformResource{
+			{Type: "aws_instance", Name: "web", ID: "i-999"},
+		},
+		ModifiedResources: []*types.ResourceDiff{
+			{ResourceType: "aws_db_instance", ResourceID: "db-1", Differences: []types.FieldDiff{
+				{Field: "instance_class", TerraformValue: "db.t3.small", ActualValue: "db.t3.large"},
+			}},
+		},
+	}
+}
+
+func TestDriftTotal(t *testing.T) {
+	if got := driftTotal(sampleDrift()); got != 3 {
+		t.Fatalf("driftTotal = %d, want 3", got)
+	}
+	if got := driftTotal(nil); got != 0 {
+		t.Fatalf("driftTotal(nil) = %d, want 0", got)
+	}
+	if got := driftTotal(&types.DriftResult{}); got != 0 {
+		t.Fatalf("driftTotal(empty) = %d, want 0", got)
+	}
+}
+
+func TestExitCodeForDrift(t *testing.T) {
+	cases := []struct {
+		total       int
+		failOnDrift bool
+		want        int
+	}{
+		{0, true, 0},                   // clean -> 0
+		{3, true, 3},                   // drift -> count
+		{5, false, 0},                  // reporting only -> 0 even with drift
+		{9999, true, maxDriftExitCode}, // capped
+	}
+	for _, c := range cases {
+		if got := exitCodeForDrift(c.total, c.failOnDrift); got != c.want {
+			t.Errorf("exitCodeForDrift(%d,%v) = %d, want %d", c.total, c.failOnDrift, got, c.want)
+		}
+	}
+}
+
+func TestRenderDriftReport_HumanCleanVsDrift(t *testing.T) {
+	clean := renderDriftReport(&types.DriftResult{}, "human", 10, 10, []string{"us-east-1"})
+	if !strings.Contains(clean, "No drift") {
+		t.Errorf("clean report should say No drift, got:\n%s", clean)
+	}
+
+	rep := renderDriftReport(sampleDrift(), "human", 10, 11, []string{"us-east-1"})
+	for _, want := range []string{
+		"Drift detected: 3", "unmanaged=1", "missing=1", "modified=1",
+		"sg-123", "aws_instance.web", "db-1", "instance_class",
+	} {
+		if !strings.Contains(rep, want) {
+			t.Errorf("human report missing %q; got:\n%s", want, rep)
+		}
+	}
+}
+
+func TestRenderDriftReport_JSONShape(t *testing.T) {
+	out := renderDriftReport(sampleDrift(), "json", 10, 11, []string{"us-east-1", "ap-northeast-1"})
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json output must parse: %v\n%s", err, out)
+	}
+	summary, ok := parsed["summary"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("json output missing summary object")
+	}
+	if summary["total_drift"].(float64) != 3 {
+		t.Errorf("summary.total_drift = %v, want 3", summary["total_drift"])
+	}
+	if _, ok := parsed["drift"]; !ok {
+		t.Errorf("json output must include drift detail")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -211,8 +211,19 @@ type PolicyConfig struct {
 	PolicyDir string `yaml:"policy_dir"` // Directory containing .rego files
 }
 
-// Load loads configuration from file
+// Load loads and validates configuration for normal (Falco-connected) operation.
 func Load(path string) (*Config, error) {
+	return load(path, (*Config).Validate)
+}
+
+// LoadForScan loads configuration for the read-only `scan` reconcile. scan does
+// not use Falco, so it validates providers/state but not the Falco connection
+// (#338) — requiring Falco to run a one-shot state-vs-cloud diff is wrong UX.
+func LoadForScan(path string) (*Config, error) {
+	return load(path, (*Config).ValidateForScan)
+}
+
+func load(path string, validate func(*Config) error) (*Config, error) {
 	if path == "" {
 		path = "config.yaml"
 	}
@@ -235,24 +246,17 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
-	// Validate configuration
-	if err := cfg.Validate(); err != nil {
+	if err := validate(&cfg); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
 	return &cfg, nil
 }
 
-// Validate validates the configuration
+// Validate validates the configuration for normal (Falco-connected) operation.
 func (c *Config) Validate() error {
-	if !c.Providers.AWS.Enabled && !c.Providers.GCP.Enabled && !c.Providers.Azure.Enabled {
-		return fmt.Errorf("at least one provider must be enabled")
-	}
-
-	if c.Providers.AWS.Enabled {
-		if len(c.Providers.AWS.Regions) == 0 {
-			return fmt.Errorf("AWS regions must be specified")
-		}
+	if err := c.validateProvidersAndTooling(); err != nil {
+		return err
 	}
 
 	// Validate Falco configuration
@@ -267,6 +271,26 @@ func (c *Config) Validate() error {
 		}
 		if c.Falco.Port == 0 {
 			return fmt.Errorf("falco port must be specified")
+		}
+	}
+
+	return nil
+}
+
+// ValidateForScan validates the subset needed by the read-only `scan` reconcile:
+// providers/state and tooling, but not the Falco connection (#338).
+func (c *Config) ValidateForScan() error {
+	return c.validateProvidersAndTooling()
+}
+
+func (c *Config) validateProvidersAndTooling() error {
+	if !c.Providers.AWS.Enabled && !c.Providers.GCP.Enabled && !c.Providers.Azure.Enabled {
+		return fmt.Errorf("at least one provider must be enabled")
+	}
+
+	if c.Providers.AWS.Enabled {
+		if len(c.Providers.AWS.Regions) == 0 {
+			return fmt.Errorf("AWS regions must be specified")
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1237,3 +1237,16 @@ func TestConfig_EdgeCaseValues(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateForScan_DoesNotRequireFalco(t *testing.T) {
+	// scan is read-only and Falco-independent: providers valid + Falco disabled
+	// must pass ValidateForScan (while full Validate still requires Falco). (#338)
+	cfg := &Config{
+		Providers: ProvidersConfig{
+			AWS: AWSConfig{Enabled: true, Regions: []string{"ap-northeast-1"}},
+		},
+		Falco: FalcoConfig{Enabled: false},
+	}
+	assert.NoError(t, cfg.ValidateForScan(), "scan must not require Falco")
+	assert.Error(t, cfg.Validate(), "full validate still requires Falco")
+}


### PR DESCRIPTION
Adds `tfdrift scan` — a **read-only, one-shot reconcile** between Terraform state and live cloud state (AWS). No Falco, no CloudTrail; deterministic and CI-friendly. This is the ADR-0014 top near-term lever: it answers the baseline question the event-only daemon structurally cannot — *"right now, does reality match my code?"* — and unblocks a nightly CI drift gate (no idle daemon).

## What it does
- `tfdrift scan --config config.yaml [--region ...] [--output human|json] [--fail-on-drift]`
- Loads Terraform state, discovers AWS resources, compares, reports **unmanaged / missing / modified**.
- **Exit code**: `0` = no drift; otherwise the drift count (capped at 250). `--fail-on-drift=false` reports only.

## Implementation (thin — reuses tested code)
- Wires the existing path used by `GET /api/v1/discovery/drift`: `StateManager.GetAllResources` + `aws.NewDiscoveryClient.DiscoverAll` + `aws.CompareStateWithActual`. **No new comparison logic.**
- Discovers **all regions first, then compares once** (per-region compare would false-flag `missing` for resources that live in another region). Dedups global resources (IAM/S3) by ID.
- Report/exit-code helpers are pure and unit-tested (human + JSON); AWS discovery/comparison is covered by existing `pkg/aws` tests.

## Tests
`go build ./...`, `go vet`, `go test ./cmd/tfdrift/` green. New: `driftTotal`, `exitCodeForDrift` (clean/drift/report-only/capped), `renderDriftReport` (human clean-vs-drift, JSON shape).

## ⚠️ Merge policy — HOLD for re-audit (per ADR-0013 / core-correctness gate)
This is **core detection correctness** (does scan catch real drift with no misses / no false-positives?). Per the agreed process, do **not** merge on CI-green alone: hold for the next checkpoint audit to verify real behavior against a live AWS account (baseline drift, multi-region, global-resource dedup, modified-attribute accuracy). CI-green here proves the deterministic scaffolding, not real-cloud correctness.

Known scope (MVP): AWS only (GCP discovery exists in the registry but the comparator is AWS-specific — follow-up). Multi-account / multi-state is ADR-0014 design work (post-8/10).

Fixes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)