### PR TITLE
docs: fix stale README version + add README to release gate (Fixes #322 #317)

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -46,9 +46,11 @@ jobs:
           DOCS_VERSION="$(grep -m1 -oE 'project_version: +"[0-9]+\.[0-9]+\.[0-9]+"' mkdocs.yml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
           DOCS_INDEX_VERSION="$(grep -m1 -oE '\*\*Version:\*\* v[0-9]+\.[0-9]+\.[0-9]+' docs/index.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
           WEBSITE_VERSION="$(grep -m1 -oE '"v[0-9]+\.[0-9]+\.[0-9]+" label="Latest Release"' website/app/page.tsx | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
-          echo "tag=v${TAG} VERSION=${FILE_VERSION} CHANGELOG=${CHANGELOG_VERSION} binary=${BINARY_VERSION} docs=${DOCS_VERSION}/${DOCS_INDEX_VERSION} website=${WEBSITE_VERSION}"
+          README_VERSION="$(grep -m1 -oE 'badge/version-[0-9]+\.[0-9]+\.[0-9]+' README.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+          README_JA_VERSION="$(grep -m1 -oE 'badge/version-[0-9]+\.[0-9]+\.[0-9]+' README.ja.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+          echo "tag=v${TAG} VERSION=${FILE_VERSION} CHANGELOG=${CHANGELOG_VERSION} binary=${BINARY_VERSION} docs=${DOCS_VERSION}/${DOCS_INDEX_VERSION} website=${WEBSITE_VERSION} README=${README_VERSION}/${README_JA_VERSION}"
           FAIL=0
-          for pair in "VERSION:${FILE_VERSION}" "CHANGELOG:${CHANGELOG_VERSION}" "binary:${BINARY_VERSION}" "mkdocs:${DOCS_VERSION}" "docs-index:${DOCS_INDEX_VERSION}" "website:${WEBSITE_VERSION}"; do
+          for pair in "VERSION:${FILE_VERSION}" "CHANGELOG:${CHANGELOG_VERSION}" "binary:${BINARY_VERSION}" "mkdocs:${DOCS_VERSION}" "docs-index:${DOCS_INDEX_VERSION}" "website:${WEBSITE_VERSION}" "README:${README_VERSION}" "README.ja:${README_JA_VERSION}"; do
             name="${pair%%:*}"; val="${pair#*:}"
             if [ "${TAG}" != "${val}" ]; then
               echo "::error::Version identity mismatch at ${name}: expected ${TAG}, found '${val}'. Align it before releasing (ADR-0002/0005)."

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,14 +2,14 @@
 
 **Falcoを活用したリアルタイムTerraformドリフト検知**
 
-[![Version](https://img.shields.io/badge/version-0.9.0-blue)](https://github.com/higakikeita/tfdrift-falco/releases)
+[![Version](https://img.shields.io/badge/version-0.14.0-blue)](https://github.com/higakikeita/tfdrift-falco/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Go Version](https://img.shields.io/badge/Go-1.21+-00ADD8?logo=go)](https://golang.org/)
+[![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go)](https://golang.org/)
 [![Falco](https://img.shields.io/badge/Falco-Compatible-blue)](https://falco.org/)
 [![Docker](https://img.shields.io/badge/Docker-GHCR-2496ED?logo=docker)](https://ghcr.io/higakikeita/tfdrift-falco)
 
-> **v0.9.0** (2026-03-29) — Azure完全対応、azurermバックエンド、WebSocket強化
-> [リリースノート](docs/release-notes/v0.9.0.md) | [CHANGELOG](CHANGELOG.md) | [ロードマップ](PROJECT_ROADMAP.md)
+> **v0.14.0** (2026-07-20) — OpenTofu 対応（`auto_import.tool: terraform|tofu`）
+> [リリースノート](docs/release-notes/v0.14.0.md) | [CHANGELOG](CHANGELOG.md) | [ロードマップ](PROJECT_ROADMAP.md)
 
 [English](README.md) | **[日本語]**
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 **Real-time Terraform Drift Detection powered by Falco**
 
-[![Version](https://img.shields.io/badge/version-0.9.0-blue)](https://github.com/higakikeita/tfdrift-falco/releases)
+[![Version](https://img.shields.io/badge/version-0.14.0-blue)](https://github.com/higakikeita/tfdrift-falco/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Go Version](https://img.shields.io/badge/Go-1.21+-00ADD8?logo=go)](https://golang.org/)
+[![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go)](https://golang.org/)
 [![Falco](https://img.shields.io/badge/Falco-Compatible-blue)](https://falco.org/)
 [![Docker](https://img.shields.io/badge/Docker-GHCR-2496ED?logo=docker)](https://ghcr.io/higakikeita/tfdrift-falco)
 
-> **v0.9.0** (2026-03-29) — Azure Full Support, azurerm backend, WebSocket enhancements
-> [Release Notes](docs/release-notes/v0.9.0.md) | [CHANGELOG](CHANGELOG.md) | [Roadmap](PROJECT_ROADMAP.md)
+> **v0.14.0** (2026-07-20) — OpenTofu support (`auto_import.tool: terraform|tofu`)
+> [Release Notes](docs/release-notes/v0.14.0.md) | [CHANGELOG](CHANGELOG.md) | [Roadmap](PROJECT_ROADMAP.md)
 
 **[English]** | [日本語](README.ja.md)
 

--- a/docs/improvement-roadmap.md
+++ b/docs/improvement-roadmap.md
@@ -211,8 +211,8 @@ Phase 1 MVP（現在）から **Phase 1.5 Enhanced MVP** への移行
 ```
 
 **成果物**:
-- [ ] アラートルール定義（`dashboards/grafana/alerts/`）
-- [ ] アラート設定ガイド（`docs/grafana-alerts.md`）
+- [ ] アラートルール定義（drift_rules / policy）
+- [ ] アラート設定ガイド（通知チャネル: Slack/Discord/webhook）
 - [ ] Slack/Discord 連携設定例
 
 **見積もり**: 3-4 時間


### PR DESCRIPTION
Cleans up the remaining "claims ≠ reality" doc items (the mechanical, high-certainty ones).

## #322 — stale README version
`README.md` / `README.ja.md` banners still showed **v0.9.0 / Go 1.21** while the project is **v0.14.0 / Go 1.25.8** — the most visible stale claim for anyone landing on the repo. Bumped the version badge, Go badge, release banner, and release-notes link to v0.14.0 (OpenTofu support). Azure-details links that point at the v0.9.0 notes (where Azure was introduced) are left as legitimate historical references.

## #317 — README in the release consistency gate
Added `README.md` and `README.ja.md` version banners to `publish-ghcr.yml`'s `verify-version-consistency` job. It now enforces **8 points** (VERSION / CHANGELOG / binary / mkdocs / docs-index / website / README / README.ja) — closing the ADR-0002 principle-2 hole that let the README banner drift five versions behind. Verified the extractor pulls `0.14.0` from both READMEs; YAML validates.

## #323 (partial) — dead Grafana link
Fixed a dead `dashboards/grafana/` link in the forward-looking `improvement-roadmap.md` (Grafana was removed in #290).

**Scope note:** historical narrative docs (`release-notes/v0.2.0-beta`, `PR_v0.2.0-beta`, qiita dev diaries) keep their point-in-time `dashboards/` references — rewriting them would be revisionism. The larger job — docs that still *instruct users to set up Grafana* (complete-setup-guide / USAGE / overview / how-it-works / best-practices) — is a separate follow-up, so #323 stays open.

## Tests
Docs + workflow YAML only (no Go/UI). `publish-ghcr.yml` validated; README version extraction confirmed. Required checks (Backend/Frontend/Integration) path-skip.

Fixes #322
Fixes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)