### PR TITLE
fix(falco): Falco 0.43.0 + cloudtrail 0.17.1 + mTLS root_certs fix (Refs #311)

### DIFF
--- a/deployments/falco/falco-simple.yaml
+++ b/deployments/falco/falco-simple.yaml
@@ -10,15 +10,14 @@ grpc:
   threadiness: 0
   private_key: "/etc/falco/certs/server.key"
   cert_chain: "/etc/falco/certs/server.crt"
-  root_certs: "/etc/falco/certs/server.crt"
+  root_certs: "/etc/falco/certs/ca.crt"
 
 # gRPC Output format
 grpc_output:
   enabled: true
 
-# Rules files
-rules_file:
-  - /etc/falco/falco_rules.yaml
+# Rules files (Falco 0.36+ uses the plural `rules_files` key)
+rules_files:
   - /etc/falco/rules.d
 
 # Output format

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # Falco - Runtime security monitoring
   # ============================================
   falco:
-    image: falcosecurity/falco:0.37.1
+    image: falcosecurity/falco:0.43.0  # 0.37.1 was too old for the current CloudTrail plugin (Plugin API 3.11+); 0.43 loads it AND still ships grpc_output. Do NOT bump to 0.44+ (grpc_output removed). See #311.
     container_name: tfdrift-falco-falco
     platform: linux/amd64  # Force x86_64 for CloudTrail plugin compatibility
     privileged: true

--- a/docs/complete-setup-guide.md
+++ b/docs/complete-setup-guide.md
@@ -254,28 +254,19 @@ state:
 
 ## Phase 3: Falco CloudTrailプラグインのセットアップ
 
-### 3.1 プラグインのダウンロード
+### 3.1 プラグインのインストール（falcoctl）
 
-FalcoのCloudTrailプラグインをダウンロードします。
+CloudTrail プラグインは、公式ツール `falcoctl` で署名検証付きインストールするのが正です（旧来の直接 tar ダウンロードは廃止）。
+
+> ⚠️ **バージョン互換（#311 で確定）**: CloudTrail プラグイン 0.17.1 は **Plugin API 3.11+** を要求します。**Falco 0.43.0** を使ってください（0.37 系では読み込めず、0.44+ は gRPC 出力が撤去され TFDrift の購読モデルでは使えません）。`docker-compose.yml` の falco イメージは 0.43.0 に固定済みです。
 
 ```bash
-cd deployments/falco/plugins
-
-# プラットフォームに応じたプラグインをダウンロード
-# ARM64 Mac の場合は x86_64 版を使用（Rosetta経由）
-PLUGIN_VERSION="0.13.0"
-PLATFORM="linux-x86_64"  # ARM64の場合もこれを使用
-
-curl -L -o cloudtrail-plugin.tar.gz \
-    "https://download.falco.org/plugins/stable/cloudtrail-${PLUGIN_VERSION}-${PLATFORM}.tar.gz"
-
-# 展開
-tar -xzf cloudtrail-plugin.tar.gz
-rm cloudtrail-plugin.tar.gz
-
-# 確認
-ls -lh libcloudtrail.so
+# Falco 0.43.0 イメージに同梱の falcoctl でインストール（Linux amd64）
+falcoctl artifact install cloudtrail:0.17.1 --plugins-dir /usr/share/falco/plugins
+# → ghcr.io/falcosecurity/plugins/plugin/cloudtrail から署名検証付きで取得
 ```
+
+Docker Compose では、falco コンテナ起動時に上記を実行してからプラグイン有効な設定で Falco を起動します（`deployments/falco/falco.yaml` の `load_plugins: [cloudtrail]`）。既定の `docker compose up -d`（`falco-simple.yaml`）はプラグイン無効の UI/API デモです。
 
 ### 3.2 Falco設定ファイルの編集
 
@@ -287,15 +278,17 @@ ls -lh libcloudtrail.so
 # CloudTrail Plugin Configuration
 plugins:
   - name: cloudtrail
-    library_path: /etc/falco/plugins/libcloudtrail.so
-    init_config: ""
-    open_params: "s3Bucket=tfdrift-cloudtrail-YOUR-AWS-ACCOUNT-ID-us-east-1"  # ← あなたのバケット名
+    library_path: libcloudtrail.so   # falcoctl installs into /usr/share/falco/plugins; Falco resolves the bare name
+    init_config: '{"sqsDelete": true}'
+    # Live SQS mode (recommended — Falco stays resident and streams new events):
+    open_params: "sqs://YOUR-CLOUDTRAIL-SQS-QUEUE-NAME"
+    # or S3 batch mode (reads the bucket once): open_params: "s3://YOUR-CLOUDTRAIL-BUCKET"
 
 # Load plugins
 load_plugins: [cloudtrail]
 ```
 
-**注意**: `s3Bucket=`の後には、Phase 1で作成したS3バケット名を指定します。
+**注意**: `open_params` は現行プラグインの URI 形式（`sqs://<queue-name>` または `s3://<bucket>`）です。旧 `s3Bucket=` 形式は使いません。SQS ライブモードには CloudTrail→S3→SNS→SQS 配線が必要です。
 
 ### 3.3 Falcoルールの確認
 


### PR DESCRIPTION
Lands the resolution the isolation work identified for #311. The real-time blocker was **version incompatibility + a cert config bug**, not tfdrift's subscribe/parse.

## Root cause (isolation probe on real infra)
- Falco **0.37.1** (Plugin API 3.2.0) can't load the current cloudtrail plugin **0.17.1** (needs API 3.11+). The bundled Apr-2025 `.so` loaded but **SIGSEGV'd on the grpc_output path**.
- Verified matrix: `0.37.1` incompatible · **`0.43.0` + `cloudtrail 0.17.1` = plugin loads AND gRPC server starts, no segfault** · `0.44+` removed `grpc_output` entirely.
- Separate bug: `falco-simple.yaml` used `server.crt` as `root_certs` → the `Invalid cert chain file` error when building the mTLS gRPC listener.

## Changes
- `docker-compose.yml`: falco `0.37.1` → `0.43.0` (pinned; **do not go 0.44+** until TFDrift migrates off gRPC output).
- `deployments/falco/falco-simple.yaml`: `root_certs` → `ca.crt`; switch to the current `rules_files` key.
- `docs/complete-setup-guide.md`: install the plugin via `falcoctl artifact install cloudtrail:0.17.1` (signed) instead of the removed 0.13.0 direct download; fix the plugin config (bare `library_path`, `sqs://`/`s3://` open_params; drop the gone `s3Bucket=` form); note the 0.43 requirement.

## Validation / scope
- Default UI/API demo booting on 0.43 is covered by the **onboarding smoke** (real Docker CI).
- Full real-time end-to-end (drift streaming to tfdrift over gRPC on 0.43 against live AWS) is the remaining confirmation → keeping #311 open (`Refs`, not `Fixes`).
- **Strategic follow-up:** gRPC output is deprecated (0.43) and **removed (0.44+)**, so TFDrift's gRPC-subscriber architecture is a dead end — migrate to Falco HTTP output / Falcosidekick before any 0.44+ bump. Worth an ADR (ties to the Falco-spine question + the falcosidekick donation work).

Refs #311