### PR TITLE
fix(helm): use supported API port flag

### DIFF
--- a/charts/tfdrift-falco/templates/deployment.yaml
+++ b/charts/tfdrift-falco/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "--server"
-            - "--port"
+            - "--api-port"
             - "{{ .Values.config.port }}"
             - "--config"
             - "/etc/tfdrift-falco/config.yaml"


### PR DESCRIPTION
The Helm chart passed `--port`, which the binary does not define — the server flag is `--api-port` (cmd/tfdrift/main.go:54). A chart-deployed pod would fail to start on an unknown flag.

Verified against main: `rootCmd.Flags().IntVar(&apiPort, "api-port", 8080, ...)` exists; no `--port` flag is registered.

Fixes #355