### PR TITLE
feat(falco): migrate Falco transport gRPC→HTTP output (ADR-006)

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -62,7 +62,14 @@ providers:
 falco:
   enabled: true
 
-  # Falco gRPC server configuration
+  # How Falco alerts reach TFDrift (ADR-006):
+  #   http  — Falco http_output POSTs alerts to POST /api/v1/falco/events on the
+  #           TFDrift API server. Works on Falco 0.44+. Recommended.
+  #   grpc  — legacy Falco gRPC Sub stream (hostname/port/cert_* below). Removed
+  #           by Falco 0.44+. Empty is treated as grpc for backward compatibility.
+  transport: "http"
+
+  # gRPC transport settings (only used when transport: grpc)
   hostname: "localhost"  # Falco gRPC server hostname
   port: 5060             # Falco gRPC server port (default: 5060)
 

--- a/docs/adr/001-event-driven-falco-grpc.md
+++ b/docs/adr/001-event-driven-falco-grpc.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted
+Accepted — the event-driven ingestion decision stands, but the **Falco→TFDrift gRPC
+transport is superseded by [ADR-006](006-falco-http-output-migration.md)** (Falco
+removed gRPC output in 0.44+).
 
 ## Date
 

--- a/docs/adr/006-falco-http-output-migration.md
+++ b/docs/adr/006-falco-http-output-migration.md
@@ -1,0 +1,98 @@
+# ADR-006: Migrate Falco event ingestion from gRPC output to HTTP output
+
+## Status
+
+Accepted (supersedes the transport choice in [ADR-001](001-event-driven-falco-grpc.md))
+
+## Date
+
+2026-07-23
+
+## Context
+
+[ADR-001](001-event-driven-falco-grpc.md) adopted an event-driven architecture that
+consumes Falco alerts over Falco's **gRPC output** API (`pkg/falco/subscriber.go`
+subscribes to `outputs.Sub` via `falcosecurity/client-go`). Real-machine verification
+of the real-time path (#311) surfaced two problems that make the gRPC transport a
+dead end:
+
+1. **Falco removed gRPC output.** Falco `0.44+` removed `grpc_output` entirely.
+   `0.43.0` still ships it but logs *"deprecated as consequence of gRPC output
+   deprecation"* on startup and dropped `private_key`/`cert_chain`/`root_certs` from
+   the grpc config schema (they still function but emit a schema-validation warning).
+   We pinned `docker-compose.yml` to `0.43.0` precisely because we could not go newer
+   (#357). Staying on gRPC pins the whole project to an EOL Falco.
+
+2. **The mTLS gRPC surface is operationally heavy.** It requires generating and
+   distributing a CA + server + client cert set, and the `root_certs` foot-gun (must
+   be `ca.crt`, not `server.crt`) already cost us real debugging time (#357).
+
+The event *ingestion* decision of ADR-001 (Cloud API → audit logs → Falco plugin →
+TFDrift → detector) is still correct and unchanged. Only the **Falco → TFDrift
+transport** needs to move off the removed gRPC path.
+
+Note: this ADR does **not** cover the separate cloudtrail-plugin continuous-ingest
+emit gap (the plugin consumes SQS-live messages but only emits reliably in S3-batch
+mode); that is tracked under the same issue (#360) and is orthogonal to the transport.
+
+### Options considered
+
+1. **Falco `http_output` → TFDrift HTTP receiver.** Falco POSTs each alert as JSON
+   to a URL. TFDrift already runs an HTTP API server, and `http_output` blocks
+   already exist (disabled) in every `deployments/falco/*.yaml`. Supported on all
+   current and future Falco versions.
+2. **Falcosidekick in between.** Falco → Falcosidekick → (many outputs). Adds a
+   second service to operate. Falcosidekick's value is *fan-out* to external sinks
+   (Slack, SIEM, OpenCTI) — a concern that belongs to the donation/observability
+   track, not to TFDrift's own event consumption.
+3. **Keep gRPC / vendor an old Falco.** Rejected: pins us to EOL Falco and keeps the
+   mTLS operational burden.
+
+## Decision
+
+Adopt **Falco `http_output` → a TFDrift HTTP receiver** as the primary Falco→TFDrift
+transport, superseding the gRPC output choice in ADR-001.
+
+- Falco is configured with `http_output.enabled: true` and `url` pointing at a new
+  TFDrift endpoint (default `POST /api/v1/falco/events`), one JSON alert per request
+  (`json_output: true`).
+- TFDrift gains an HTTP receiver that parses the Falco alert JSON into the existing
+  `types.Event` and feeds the **same** downstream pipeline (parser → resource mapper →
+  detector → broadcaster). The parsing/extraction logic in `subscriber.go`
+  (`ParseFalcoOutput`, `ExtractChanges`, `ExtractResourceID`) is reused, not rewritten.
+- The gRPC subscriber is kept for one release as an opt-in fallback
+  (`falco.transport: grpc|http`, default `http`) and then removed, so existing 0.43
+  deployments are not broken on upgrade.
+- Falcosidekick is explicitly out of scope here and left to the donation track.
+
+The updated pipeline: Cloud API → audit logs → Falco plugin → **Falco http_output** →
+**TFDrift HTTP receiver** → event parser → resource mapper → drift detector →
+broadcaster → UI.
+
+## Consequences
+
+### Positive
+
+- Works on current and future Falco (unpins us from EOL `0.43.0`; unblocks `0.44+`).
+- Drops the mTLS cert set and the `root_certs` foot-gun for the default path; auth
+  becomes a standard HTTP concern (shared secret / bearer, aligned with the API's
+  own auth work in #341).
+- Reuses the existing HTTP server and the existing parse/extract code — small blast
+  radius.
+- One less streaming/reconnect surface to own (the reconnect logic added in #312 was
+  gRPC-stream-specific).
+
+### Negative
+
+- Push model: Falco must reach TFDrift's URL (network/DNS/ingress), where gRPC was a
+  pull subscription. Mitigated by co-locating in the same compose/Helm network.
+- A brief two-transport window (grpc + http) until the gRPC path is removed.
+- The HTTP receiver must be hardened (auth, body size limits, source restriction) —
+  folded into the API-auth hardening (#341) rather than solved twice.
+
+### Follow-ups
+
+- Implement the receiver + `falco.transport` switch (#360).
+- Flip `http_output` on and `grpc_output` off in `deployments/**` and
+  `docker-compose.yml`; re-verify real-time end-to-end on real AWS before closing #311.
+- Remove the gRPC subscriber one release later.

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	google.golang.org/api v0.289.0
 	google.golang.org/grpc v1.82.0
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -125,6 +126,5 @@ require (
 	google.golang.org/genproto v0.0.0-20260519071638-aa98bba5eb94 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260706201446-f0a921348800 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -106,6 +106,14 @@ func (s *Server) setupRouter() {
 		// SSE endpoint (Phase 4) - no timeout middleware for streaming
 		r.Get("/stream", s.sseHandler.HandleSSE)
 
+		// Falco HTTP-output receiver (ADR-006). Only mounted when the Falco
+		// transport is "http"; Falco POSTs one JSON alert per request here.
+		// Auth/source-restriction for this ingress is folded into the API-wide
+		// auth work (#341); until then the API binds to localhost only (#328).
+		if s.detector != nil && s.detector.UsesHTTPFalcoTransport() {
+			r.Post("/falco/events", s.detector.FalcoHTTPHandler())
+		}
+
 		// Regular API routes with timeout
 		r.Group(func(r chi.Router) {
 			// Timeout for non-streaming API routes

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -253,11 +253,15 @@ func (c *Config) Validate() error {
 	if !c.Falco.Enabled {
 		return fmt.Errorf("falco must be enabled - TFDrift-Falco requires Falco gRPC connection")
 	}
-	if c.Falco.Hostname == "" {
-		return fmt.Errorf("falco hostname must be specified")
-	}
-	if c.Falco.Port == 0 {
-		return fmt.Errorf("falco port must be specified")
+	// hostname/port only apply to the legacy gRPC transport; the HTTP transport
+	// receives alerts on the API server and needs neither (ADR-006).
+	if !c.Falco.UsesHTTPTransport() {
+		if c.Falco.Hostname == "" {
+			return fmt.Errorf("falco hostname must be specified")
+		}
+		if c.Falco.Port == 0 {
+			return fmt.Errorf("falco port must be specified")
+		}
 	}
 
 	// Validate IaC tool selection (empty is allowed and means terraform)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,12 +91,27 @@ type AzureConfig struct {
 
 // FalcoConfig contains Falco integration settings
 type FalcoConfig struct {
-	Enabled    bool   `yaml:"enabled" mapstructure:"enabled"`
+	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
+
+	// Transport selects how Falco alerts reach TFDrift (ADR-006):
+	//   "http" — Falco http_output POSTs to the TFDrift HTTP receiver (default
+	//            path going forward; works on Falco 0.44+).
+	//   "grpc" — legacy Falco gRPC Sub stream (Hostname/Port/Cert*). Removed by
+	//            Falco 0.44+; kept for one release. Empty is treated as "grpc"
+	//            for backward compatibility until deployments flip to http_output.
+	Transport string `yaml:"transport" mapstructure:"transport"`
+
 	Hostname   string `yaml:"hostname" mapstructure:"hostname"`
 	Port       uint16 `yaml:"port" mapstructure:"port"`
 	CertFile   string `yaml:"cert_file" mapstructure:"cert_file"`
 	KeyFile    string `yaml:"key_file" mapstructure:"key_file"`
 	CARootFile string `yaml:"ca_root_file" mapstructure:"ca_root_file"`
+}
+
+// UsesHTTPTransport reports whether Falco alerts arrive over the HTTP receiver
+// rather than the legacy gRPC stream (ADR-006).
+func (f FalcoConfig) UsesHTTPTransport() bool {
+	return f.Transport == "http"
 }
 
 // DriftRule defines a drift detection rule

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -177,6 +177,26 @@ func TestValidate_FalcoMissingHostname(t *testing.T) {
 	assert.Contains(t, err.Error(), "falco hostname must be specified")
 }
 
+func TestValidate_FalcoHTTPTransportNeedsNoHostname(t *testing.T) {
+	// The HTTP transport receives alerts on the API server, so the gRPC-only
+	// hostname/port are not required (ADR-006).
+	cfg := &Config{
+		Providers: ProvidersConfig{
+			AWS: AWSConfig{
+				Enabled: true,
+				Regions: []string{"us-east-1"},
+			},
+		},
+		Falco: FalcoConfig{
+			Enabled:   true,
+			Transport: "http",
+			// no Hostname, no Port
+		},
+	}
+
+	assert.NoError(t, cfg.Validate())
+}
+
 func TestValidate_FalcoMissingPort(t *testing.T) {
 	cfg := &Config{
 		Providers: ProvidersConfig{

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -2,6 +2,7 @@ package detector
 
 import (
 	"fmt"
+	"net/http"
 	"sync"
 
 	"github.com/keitahigaki/tfdrift-falco/pkg/api/broadcaster"
@@ -29,6 +30,20 @@ func (d *Detector) FalcoReadiness() (bool, map[string]string) {
 		return true, map[string]string{"falco": "connected"}
 	}
 	return false, map[string]string{"falco": "disconnected"}
+}
+
+// UsesHTTPFalcoTransport reports whether Falco alerts arrive over the HTTP
+// receiver instead of the legacy gRPC stream (ADR-006). The API server uses it
+// to decide whether to mount the Falco HTTP receiver route.
+func (d *Detector) UsesHTTPFalcoTransport() bool {
+	return d.cfg.Falco.Enabled && d.cfg.Falco.UsesHTTPTransport()
+}
+
+// FalcoHTTPHandler returns the receiver that ingests Falco http_output alerts
+// onto the same event channel the gRPC path feeds, so downstream processing is
+// identical regardless of transport (ADR-006).
+func (d *Detector) FalcoHTTPHandler() http.HandlerFunc {
+	return d.falcoSubscriber.HTTPHandler(d.eventCh)
 }
 
 // alertNotifier delivers drift alerts to the configured channels. It is an

--- a/pkg/detector/lifecycle.go
+++ b/pkg/detector/lifecycle.go
@@ -51,9 +51,18 @@ func (d *Detector) Start(ctx context.Context) error {
 	return nil
 }
 
-// startCollectors starts the Falco event subscriber
+// startCollectors starts the Falco event source. With the HTTP transport
+// (ADR-006) there is no outbound stream to maintain — Falco POSTs alerts to the
+// receiver route mounted by the API server — so this goroutine just parks until
+// shutdown. With the legacy gRPC transport it runs the reconnecting Sub loop.
 func (d *Detector) startCollectors(ctx context.Context) error {
-	log.Info("Starting Falco subscriber...")
+	if d.cfg.Falco.UsesHTTPTransport() {
+		log.Info("Falco transport=http: ingesting alerts via the HTTP receiver route")
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	log.Info("Starting Falco subscriber (transport=grpc)...")
 	if err := d.falcoSubscriber.Start(ctx, d.eventCh); err != nil {
 		return fmt.Errorf("falco subscriber error: %w", err)
 	}

--- a/pkg/falco/http_receiver.go
+++ b/pkg/falco/http_receiver.go
@@ -1,10 +1,12 @@
 package falco
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,16 +23,41 @@ import (
 const maxFalcoBodyBytes = 1 << 20
 
 // falcoAlert mirrors the JSON Falco emits via http_output when json_output is
-// enabled. Only the fields the parsers consume are decoded (ADR-006).
+// enabled (ADR-006). output_fields is deliberately map[string]interface{}: real
+// Falco emits mixed value types there — e.g. "ct.request.name": null and
+// "evt.time.iso8601": <number> alongside string fields — so decoding straight
+// into map[string]string rejects real alerts. coerceFields normalizes it.
 type falcoAlert struct {
-	Time         time.Time         `json:"time"`
-	Priority     string            `json:"priority"`
-	Rule         string            `json:"rule"`
-	Output       string            `json:"output"`
-	Source       string            `json:"source"`
-	Hostname     string            `json:"hostname"`
-	Tags         []string          `json:"tags"`
-	OutputFields map[string]string `json:"output_fields"`
+	Time         time.Time              `json:"time"`
+	Priority     string                 `json:"priority"`
+	Rule         string                 `json:"rule"`
+	Output       string                 `json:"output"`
+	Source       string                 `json:"source"`
+	Hostname     string                 `json:"hostname"`
+	Tags         []string               `json:"tags"`
+	OutputFields map[string]interface{} `json:"output_fields"`
+}
+
+// coerceFields flattens Falco's mixed-type output_fields to the map[string]string
+// the parsers expect: strings pass through, numbers/bools are stringified (via
+// json.Number so large integers keep full precision), and nulls are dropped.
+func coerceFields(raw map[string]interface{}) map[string]string {
+	out := make(map[string]string, len(raw))
+	for k, v := range raw {
+		switch val := v.(type) {
+		case nil:
+			// e.g. "ct.request.name": null — omit rather than store ""
+		case string:
+			out[k] = val
+		case json.Number:
+			out[k] = val.String()
+		case bool:
+			out[k] = strconv.FormatBool(val)
+		default:
+			out[k] = fmt.Sprintf("%v", val)
+		}
+	}
+	return out
 }
 
 // toResponse adapts a decoded http_output alert into the gRPC outputs.Response
@@ -43,7 +70,7 @@ func (a falcoAlert) toResponse() *outputs.Response {
 		Source:       a.Source,
 		Hostname:     a.Hostname,
 		Tags:         a.Tags,
-		OutputFields: a.OutputFields,
+		OutputFields: coerceFields(a.OutputFields),
 	}
 	// Falco sends the priority as a name ("Warning"); the proto wants the enum.
 	if v, ok := schema.Priority_value[strings.ToUpper(a.Priority)]; ok {
@@ -63,7 +90,9 @@ func (a falcoAlert) toResponse() *outputs.Response {
 // Exposed for unit testing the HTTP transport independently of a live server.
 func (s *Subscriber) ParseHTTPAlert(body []byte) (*types.Event, error) {
 	var a falcoAlert
-	if err := json.Unmarshal(body, &a); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber() // keep large integer output_fields (e.g. evt.time.iso8601) exact
+	if err := dec.Decode(&a); err != nil {
 		return nil, fmt.Errorf("decode Falco alert: %w", err)
 	}
 	if a.Source == "" {

--- a/pkg/falco/http_receiver.go
+++ b/pkg/falco/http_receiver.go
@@ -1,0 +1,117 @@
+package falco
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/falcosecurity/client-go/pkg/api/outputs"
+	"github.com/falcosecurity/client-go/pkg/api/schema"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/keitahigaki/tfdrift-falco/pkg/types"
+	log "github.com/sirupsen/logrus"
+)
+
+// maxFalcoBodyBytes caps the request body Falco's http_output may POST so a
+// misconfigured or hostile sender cannot exhaust memory. A single Falco alert
+// is a few KB; 1 MiB is generous.
+const maxFalcoBodyBytes = 1 << 20
+
+// falcoAlert mirrors the JSON Falco emits via http_output when json_output is
+// enabled. Only the fields the parsers consume are decoded (ADR-006).
+type falcoAlert struct {
+	Time         time.Time         `json:"time"`
+	Priority     string            `json:"priority"`
+	Rule         string            `json:"rule"`
+	Output       string            `json:"output"`
+	Source       string            `json:"source"`
+	Hostname     string            `json:"hostname"`
+	Tags         []string          `json:"tags"`
+	OutputFields map[string]string `json:"output_fields"`
+}
+
+// toResponse adapts a decoded http_output alert into the gRPC outputs.Response
+// the existing parsers already understand, so both transports share one parse
+// path instead of duplicating the AWS/GCP/Azure field extraction (ADR-006).
+func (a falcoAlert) toResponse() *outputs.Response {
+	res := &outputs.Response{
+		Rule:         a.Rule,
+		Output:       a.Output,
+		Source:       a.Source,
+		Hostname:     a.Hostname,
+		Tags:         a.Tags,
+		OutputFields: a.OutputFields,
+	}
+	// Falco sends the priority as a name ("Warning"); the proto wants the enum.
+	if v, ok := schema.Priority_value[strings.ToUpper(a.Priority)]; ok {
+		res.Priority = schema.Priority(v)
+	}
+	if !a.Time.IsZero() {
+		res.Time = &timestamp.Timestamp{
+			Seconds: a.Time.Unix(),
+			Nanos:   int32(a.Time.Nanosecond()),
+		}
+	}
+	return res
+}
+
+// ParseHTTPAlert decodes a single Falco http_output alert body into a TFDrift
+// event via the shared parse path. Returns (nil, nil) when the alert is valid
+// but not drift-relevant (e.g. a read-only event), mirroring parseFalcoOutput.
+// Exposed for unit testing the HTTP transport independently of a live server.
+func (s *Subscriber) ParseHTTPAlert(body []byte) (*types.Event, error) {
+	var a falcoAlert
+	if err := json.Unmarshal(body, &a); err != nil {
+		return nil, fmt.Errorf("decode Falco alert: %w", err)
+	}
+	if a.Source == "" {
+		return nil, fmt.Errorf("Falco alert missing source")
+	}
+	return s.parseFalcoOutput(a.toResponse()), nil
+}
+
+// HTTPHandler returns the HTTP counterpart of the gRPC Sub stream (ADR-006):
+// Falco's http_output POSTs one JSON alert per request, and each parsed drift
+// event is fed onto eventCh — the same channel the gRPC path uses, so the
+// downstream detector/broadcaster pipeline is unchanged.
+func (s *Subscriber) HTTPHandler(eventCh chan<- types.Event) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxFalcoBodyBytes))
+		if err != nil {
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+
+		event, err := s.ParseHTTPAlert(body)
+		if err != nil {
+			log.Warnf("Falco http_output: %v", err)
+			http.Error(w, "bad alert", http.StatusBadRequest)
+			return
+		}
+
+		// Receiving a well-formed alert means Falco is alive and reaching us:
+		// surface it the same way the gRPC stream does so /health does not
+		// report "ok" while silently receiving nothing (pus #9).
+		s.connected.Store(true)
+
+		if event != nil {
+			select {
+			case eventCh <- *event:
+				log.Debugf("Falco http_output event queued: %s", event.EventName)
+			case <-r.Context().Done():
+				http.Error(w, "shutting down", http.StatusServiceUnavailable)
+				return
+			}
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+	}
+}

--- a/pkg/falco/http_receiver.go
+++ b/pkg/falco/http_receiver.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/falcosecurity/client-go/pkg/api/outputs"
 	"github.com/falcosecurity/client-go/pkg/api/schema"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/keitahigaki/tfdrift-falco/pkg/types"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // maxFalcoBodyBytes caps the request body Falco's http_output may POST so a
@@ -50,10 +50,9 @@ func (a falcoAlert) toResponse() *outputs.Response {
 		res.Priority = schema.Priority(v)
 	}
 	if !a.Time.IsZero() {
-		res.Time = &timestamp.Timestamp{
-			Seconds: a.Time.Unix(),
-			Nanos:   int32(a.Time.Nanosecond()),
-		}
+		// timestamp.Timestamp (what outputs.Response.Time wants) is a type alias
+		// for timestamppb.Timestamp, so the modern constructor assigns directly.
+		res.Time = timestamppb.New(a.Time)
 	}
 	return res
 }

--- a/pkg/falco/http_receiver.go
+++ b/pkg/falco/http_receiver.go
@@ -68,7 +68,7 @@ func (s *Subscriber) ParseHTTPAlert(body []byte) (*types.Event, error) {
 		return nil, fmt.Errorf("decode Falco alert: %w", err)
 	}
 	if a.Source == "" {
-		return nil, fmt.Errorf("Falco alert missing source")
+		return nil, fmt.Errorf("missing source in Falco alert")
 	}
 	return s.parseFalcoOutput(a.toResponse()), nil
 }

--- a/pkg/falco/http_receiver_test.go
+++ b/pkg/falco/http_receiver_test.go
@@ -1,6 +1,7 @@
 package falco
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -42,6 +43,34 @@ func TestParseHTTPAlert_ValidDriftEvent(t *testing.T) {
 
 	assert.Equal(t, "i-1234567890abcdef0", event.ResourceID)
 	assert.Equal(t, "ModifyInstanceAttribute", event.EventName)
+}
+
+// realFalcoAuthorizeAlert is a verbatim Falco 0.43 http_output body captured on
+// real infra (#360 verification). Note output_fields mixes types: "ct.request.name"
+// is null and "evt.time.iso8601" is a large integer. Decoding this straight into
+// map[string]string returned HTTP 400 — this locks that regression.
+const realFalcoAuthorizeAlert = `{"hostname":"cca3f82eb5b6","output":"Warning Potential Terraform drift detected","output_fields":{"ct.name":"AuthorizeSecurityGroupIngress","ct.region":"ap-northeast-1","ct.request.name":null,"ct.srcip":"221.113.81.87","ct.user":"ADMIN_OKTA_TEST","ct.user.accountid":"230446364776","evt.time.iso8601":1784730281000000000},"priority":"Warning","rule":"Terraform Managed Resource Modified","source":"aws_cloudtrail","tags":["drift","iac","terraform"],"time":"2026-07-22T14:24:41.000000000Z"}`
+
+func TestParseHTTPAlert_RealFalcoMixedTypeFields(t *testing.T) {
+	sub := NewSubscriberWithDefaults()
+
+	// Must not error on null / numeric output_fields (the HTTP 400 regression).
+	_, err := sub.ParseHTTPAlert([]byte(realFalcoAuthorizeAlert))
+	require.NoError(t, err)
+}
+
+func TestCoerceFields_MixedTypes(t *testing.T) {
+	got := coerceFields(map[string]interface{}{
+		"str":  "keep",
+		"null": nil,
+		"num":  json.Number("1784730281000000000"),
+		"bool": true,
+	})
+	assert.Equal(t, "keep", got["str"])
+	assert.Equal(t, "1784730281000000000", got["num"], "large ints must keep precision")
+	assert.Equal(t, "true", got["bool"])
+	_, hasNull := got["null"]
+	assert.False(t, hasNull, "null fields must be dropped, not stored as empty")
 }
 
 func TestParseHTTPAlert_Errors(t *testing.T) {

--- a/pkg/falco/http_receiver_test.go
+++ b/pkg/falco/http_receiver_test.go
@@ -1,0 +1,107 @@
+package falco
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/keitahigaki/tfdrift-falco/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sampleFalcoHTTPAlert is a real Falco http_output body (json_output: true) for
+// a drift-relevant CloudTrail event — the same field set the gRPC path parses,
+// so it proves the two transports share one parse path (ADR-006).
+const sampleFalcoHTTPAlert = `{
+  "time": "2026-07-22T14:24:41.000000000Z",
+  "priority": "Warning",
+  "rule": "Terraform Managed Resource Modified",
+  "source": "aws_cloudtrail",
+  "hostname": "falco",
+  "tags": ["terraform","drift","iac"],
+  "output_fields": {
+    "ct.name": "ModifyInstanceAttribute",
+    "ct.request.instanceid": "i-1234567890abcdef0",
+    "ct.request.instancetype": "t3.medium",
+    "ct.user.type": "IAMUser",
+    "ct.user.principalid": "AIDAI123456789",
+    "ct.user.arn": "arn:aws:iam::123456789012:user/admin",
+    "ct.user.accountid": "123456789012",
+    "ct.user": "admin"
+  }
+}`
+
+func TestParseHTTPAlert_ValidDriftEvent(t *testing.T) {
+	sub := NewSubscriberWithDefaults()
+
+	event, err := sub.ParseHTTPAlert([]byte(sampleFalcoHTTPAlert))
+	require.NoError(t, err)
+	require.NotNil(t, event, "a drift-relevant alert must yield an event")
+
+	assert.Equal(t, "i-1234567890abcdef0", event.ResourceID)
+	assert.Equal(t, "ModifyInstanceAttribute", event.EventName)
+}
+
+func TestParseHTTPAlert_Errors(t *testing.T) {
+	sub := NewSubscriberWithDefaults()
+
+	_, err := sub.ParseHTTPAlert([]byte(`{not json`))
+	assert.Error(t, err, "malformed JSON must error")
+
+	_, err = sub.ParseHTTPAlert([]byte(`{"rule":"x","output_fields":{}}`))
+	assert.Error(t, err, "missing source must error")
+}
+
+func TestHTTPHandler_PostDeliversEventToChannel(t *testing.T) {
+	sub := NewSubscriberWithDefaults()
+	eventCh := make(chan types.Event, 1)
+
+	srv := httptest.NewServer(sub.HTTPHandler(eventCh))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL, "application/json", strings.NewReader(sampleFalcoHTTPAlert))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+
+	select {
+	case got := <-eventCh:
+		assert.Equal(t, "i-1234567890abcdef0", got.ResourceID)
+	default:
+		t.Fatal("expected a drift event on the channel")
+	}
+
+	// Receiving a well-formed alert marks the subscriber connected (pus #9).
+	assert.True(t, sub.Connected())
+}
+
+func TestHTTPHandler_RejectsBadRequests(t *testing.T) {
+	sub := NewSubscriberWithDefaults()
+	eventCh := make(chan types.Event, 1)
+	handler := sub.HTTPHandler(eventCh)
+
+	// Non-POST is rejected.
+	rr := httptest.NewRecorder()
+	handler(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+
+	// Malformed body is a 400, not a panic.
+	rr = httptest.NewRecorder()
+	handler(rr, httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{bad`)))
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestHTTPHandler_IrrelevantEventAcceptedButNotQueued(t *testing.T) {
+	sub := NewSubscriberWithDefaults()
+	eventCh := make(chan types.Event, 1)
+	handler := sub.HTTPHandler(eventCh)
+
+	// A read-only event is a valid alert but not drift — accepted, not queued.
+	readOnly := `{"source":"aws_cloudtrail","output_fields":{"ct.name":"DescribeInstances"}}`
+	rr := httptest.NewRecorder()
+	handler(rr, httptest.NewRequest(http.MethodPost, "/", strings.NewReader(readOnly)))
+	assert.Equal(t, http.StatusAccepted, rr.Code)
+	assert.Len(t, eventCh, 0, "read-only events must not be queued as drift")
+}


### PR DESCRIPTION
## What

Migrate the Falco→TFDrift transport off the removed gRPC output onto Falco
`http_output` → a TFDrift HTTP receiver (**ADR-006**, supersedes ADR-001's
transport choice). Falco removed `grpc_output` in 0.44+ (0.43 logs it deprecated),
which is why #357 had to pin Falco to 0.43; this unpins us.

## Changes

- **docs/adr/006** — records the migration; ADR-001 marked transport-superseded.
- **pkg/falco/http_receiver.go** — decode a Falco `http_output` alert and adapt it
  to the existing `outputs.Response` so the AWS/GCP/Azure parsers are **reused, not
  duplicated**. Feeds the same `eventCh` the gRPC path uses → downstream
  detector/broadcaster pipeline unchanged. Body-size cap, read-only events
  accepted-but-not-queued, sets `connected` for `/health` (pus #9).
- **config** — `falco.transport: http|grpc` (empty = grpc for back-compat).
- **detector / lifecycle / api** — mount `POST /api/v1/falco/events` when
  `transport=http`; with http there is no outbound stream so the collector parks
  until shutdown; grpc keeps the reconnect loop.
- **config.yaml.example** — documents the new key (no phantom keys, #320).

## Tests (real behavior)

`pkg/falco/http_receiver_test.go` — a real `http_output` body → `types.Event`
(ResourceID + EventName), channel delivery, method/JSON/missing-source rejection,
read-only filtering. All green; `go vet`, gofmt, and `pkg/{falco,detector,config}`
tests pass.

## Not in this PR (held per #360 DoD — needs real-machine re-verify)

- Flip `http_output` on / `grpc_output` off + `transport: http` in
  `docker-compose.yml` + `deployments/**`.
- Confirm real-time end-to-end on live AWS, then close #311.
- Remove the gRPC subscriber one release later.

Also still open under #360: the cloudtrail-plugin SQS-live emit gap (orthogonal to
transport — the plugin emits in S3-batch but not SQS-live; see #311 verification).

Refs #360
