### PR TITLE
fix(detection): resource-attributed drift via ct.request JSON (#362)

### DIFF
--- a/pkg/detector/e2e_http_drift_test.go
+++ b/pkg/detector/e2e_http_drift_test.go
@@ -1,0 +1,132 @@
+package detector
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keitahigaki/tfdrift-falco/pkg/config"
+	"github.com/keitahigaki/tfdrift-falco/pkg/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// managedInstanceState is a Terraform state with one managed aws_instance, so a
+// CloudTrail change to it is a *managed-resource* drift (not "unmanaged").
+const managedInstanceState = `{
+  "version": 4, "terraform_version": "1.9.0", "serial": 1,
+  "lineage": "00000000-0000-0000-0000-000000000000", "outputs": {},
+  "resources": [
+    { "mode": "managed", "type": "aws_instance", "name": "web",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [ { "attributes": {
+        "id": "i-0moneyshotdemo01", "instance_type": "t3.micro"
+      } } ] }
+  ]
+}`
+
+// realFalcoModifyAlert is the money-shot Falco 0.43 http_output body: a
+// ModifyInstanceAttribute whose resource id lives *only* inside the aggregate
+// ct.request JSON (the cloudtrail plugin 0.17.1 does not expose
+// ct.request.instanceid). Extracting the id from ct.request is the #362 fix.
+const realFalcoModifyAlert = `{
+  "priority": "Warning",
+  "rule": "Terraform Managed Resource Modified",
+  "source": "aws_cloudtrail",
+  "time": "2026-07-23T09:40:55Z",
+  "output_fields": {
+    "ct.name": "ModifyInstanceAttribute",
+    "ct.region": "ap-northeast-1",
+    "ct.request": "{\"instanceId\":\"i-0moneyshotdemo01\",\"instanceType\":{\"value\":\"t3.xlarge\"}}",
+    "ct.user": "ADMIN_OKTA_TEST",
+    "ct.user.accountid": "230446364776"
+  }
+}`
+
+// falcoAlertNoResourceID has a ct.request with no id key — a valid alert that
+// must NOT produce a drift (the id is genuinely unknown), proving we don't
+// silently attribute drift to the wrong/empty resource.
+const falcoAlertNoResourceID = `{
+  "priority": "Warning", "rule": "Terraform Managed Resource Modified",
+  "source": "aws_cloudtrail",
+  "output_fields": { "ct.name": "ModifyInstanceAttribute", "ct.request": "{\"clientToken\":\"abc\"}" }
+}`
+
+// startDetectorWithState boots a detector over a local-state fixture with the
+// HTTP Falco transport — no AWS, no Falco, no plugin — and returns the mounted
+// receiver handler plus the graph store drifts land in.
+func startDetectorWithState(t *testing.T, stateJSON string) (http.HandlerFunc, *graph.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "terraform.tfstate")
+	require.NoError(t, os.WriteFile(statePath, []byte(stateJSON), 0o600))
+
+	cfg := &config.Config{}
+	cfg.Providers.AWS.Enabled = true
+	cfg.Providers.AWS.Regions = []string{"ap-northeast-1"}
+	cfg.Providers.AWS.State.Backend = "local"
+	cfg.Providers.AWS.State.LocalPath = statePath
+	cfg.Falco.Enabled = true
+	cfg.Falco.Transport = "http"
+
+	det, err := New(cfg)
+	require.NoError(t, err)
+
+	gs := graph.NewStore()
+	det.SetGraphStore(gs)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = det.Start(ctx) }()
+
+	// Wait until state is loaded so managed-resource lookups succeed.
+	require.Eventually(t, func() bool {
+		return det.GetStateManager() != nil && det.GetStateManager().ResourceCount() > 0
+	}, 3*time.Second, 20*time.Millisecond, "terraform state should load")
+
+	return det.FalcoHTTPHandler(), gs
+}
+
+func postAlert(t *testing.T, handler http.HandlerFunc, body string) int {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	handler(rr, httptest.NewRequest(http.MethodPost, "/api/v1/falco/events", strings.NewReader(body)))
+	return rr.Code
+}
+
+// TestE2E_HTTPAlertToResourceAttributedDrift is the AWS-free reproduction of the
+// money-shot (#365, merge gate for #363): a real Falco http_output alert whose
+// id lives only in ct.request flows receiver → parser → detector and emits a
+// drift attributed to the real resource id — not resource=<NA>.
+func TestE2E_HTTPAlertToResourceAttributedDrift(t *testing.T) {
+	handler, gs := startDetectorWithState(t, managedInstanceState)
+
+	require.Equal(t, http.StatusAccepted, postAlert(t, handler, realFalcoModifyAlert))
+
+	require.Eventually(t, func() bool {
+		return len(gs.GetDrifts()) > 0
+	}, 3*time.Second, 20*time.Millisecond, "a drift should be emitted for the managed resource")
+
+	drifts := gs.GetDrifts()
+	require.NotEmpty(t, drifts)
+	assert.Equal(t, "i-0moneyshotdemo01", drifts[0].ResourceID,
+		"resource id must be extracted from ct.request, not <NA>")
+	assert.Equal(t, "aws_instance", drifts[0].ResourceType)
+}
+
+// TestE2E_HTTPAlertWithoutResourceIDEmitsNoDrift is the negative case: a valid
+// alert whose ct.request carries no id must not fabricate a drift.
+func TestE2E_HTTPAlertWithoutResourceIDEmitsNoDrift(t *testing.T) {
+	handler, gs := startDetectorWithState(t, managedInstanceState)
+
+	require.Equal(t, http.StatusAccepted, postAlert(t, handler, falcoAlertNoResourceID))
+
+	// Give the processor time to (not) produce a drift.
+	time.Sleep(500 * time.Millisecond)
+	assert.Empty(t, gs.GetDrifts(), "no resource id → no drift (not a silent misattribution)")
+}

--- a/pkg/falco/event_parser.go
+++ b/pkg/falco/event_parser.go
@@ -2,6 +2,9 @@
 package falco
 
 import (
+	"encoding/json"
+	"strings"
+
 	"github.com/falcosecurity/client-go/pkg/api/outputs"
 	"github.com/keitahigaki/tfdrift-falco/pkg/types"
 	log "github.com/sirupsen/logrus"
@@ -122,5 +125,46 @@ func (s *Subscriber) extractResourceID(eventName string, fields map[string]strin
 		}
 	}
 
+	// Fallback: cloudtrail plugin 0.17.1 does not expose per-service id fields
+	// (ct.request.instanceid, ct.request.groupid, …) — only the aggregate
+	// ct.request (full requestParameters JSON). Pull the id out of that JSON
+	// using the same candidate field names (#362).
+	if id := resourceIDFromRequestJSON(fields, possibleFields); id != "" {
+		return id
+	}
+
+	return ""
+}
+
+// resourceIDFromRequestJSON extracts a resource ID from the plugin's aggregate
+// ct.request field (the full requestParameters JSON). For each candidate field
+// (e.g. "ct.request.instanceid") it strips the prefix and looks the key up
+// case-insensitively in the JSON — CloudTrail keys are camelCase (instanceId,
+// groupId, bucketName), while the mapping uses lowercase (#362).
+func resourceIDFromRequestJSON(fields map[string]string, candidates []string) string {
+	raw := getStringField(fields, "ct.request")
+	if raw == "" {
+		return ""
+	}
+	var req map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		return ""
+	}
+	// Index top-level keys case-insensitively once.
+	byLower := make(map[string]interface{}, len(req))
+	for k, v := range req {
+		byLower[strings.ToLower(k)] = v
+	}
+	for _, cand := range candidates {
+		key := cand
+		if i := strings.LastIndex(key, "."); i >= 0 {
+			key = key[i+1:]
+		}
+		if v, ok := byLower[strings.ToLower(key)]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
 	return ""
 }

--- a/pkg/falco/event_parser_test.go
+++ b/pkg/falco/event_parser_test.go
@@ -1057,3 +1057,42 @@ func TestAWSParser_mapEventToResourceType_UnknownEvent(t *testing.T) {
 		})
 	}
 }
+
+// TestExtractResourceID_FromRequestJSON locks the #362 fix: cloudtrail plugin
+// 0.17.1 exposes only the aggregate ct.request (full requestParameters JSON),
+// not per-service id fields, so the resource ID must be pulled out of that JSON
+// via case-insensitive key match. Payloads mirror real Falco http_output.
+func TestExtractResourceID_FromRequestJSON(t *testing.T) {
+	sub := NewSubscriberWithDefaults()
+
+	tests := []struct {
+		name      string
+		eventName string
+		fields    map[string]string
+		want      string
+	}{
+		{
+			name:      "EC2 instanceId out of ct.request JSON",
+			eventName: "ModifyInstanceAttribute",
+			fields:    map[string]string{"ct.request": `{"instanceId":"i-0moneyshotdemo01","instanceType":{"value":"t3.xlarge"}}`},
+			want:      "i-0moneyshotdemo01",
+		},
+		{
+			name:      "SG groupId out of ct.request JSON",
+			eventName: "AuthorizeSecurityGroupIngress",
+			fields:    map[string]string{"ct.request": `{"groupId":"sg-056b65b187cd8ece3","ipPermissions":{}}`},
+			want:      "sg-056b65b187cd8ece3",
+		},
+		{
+			name:      "no ct.request yields empty",
+			eventName: "ModifyInstanceAttribute",
+			fields:    map[string]string{"ct.name": "ModifyInstanceAttribute"},
+			want:      "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sub.extractResourceID(tt.eventName, tt.fields))
+		})
+	}
+}

--- a/pkg/falco/http_receiver.go
+++ b/pkg/falco/http_receiver.go
@@ -54,7 +54,14 @@ func coerceFields(raw map[string]interface{}) map[string]string {
 		case bool:
 			out[k] = strconv.FormatBool(val)
 		default:
-			out[k] = fmt.Sprintf("%v", val)
+			// Objects/arrays (e.g. ct.request may arrive as a nested object)
+			// are re-marshaled to JSON so downstream can parse them, rather
+			// than Go's %v map rendering which is not valid JSON.
+			if b, err := json.Marshal(val); err == nil {
+				out[k] = string(b)
+			} else {
+				out[k] = fmt.Sprintf("%v", val)
+			}
 		}
 	}
 	return out

--- a/rules/terraform_drift.yaml
+++ b/rules/terraform_drift.yaml
@@ -66,6 +66,7 @@
     (user=%ct.user
      event=%ct.name
      resource=%ct.request.name
+     request=%ct.request
      region=%ct.region
      source_ip=%ct.srcip
      aws_account=%ct.user.accountid)
@@ -89,6 +90,7 @@
     (user=%ct.user
      event=%ct.name
      resource=%ct.request.name
+     request=%ct.request
      region=%ct.region
      source_ip=%ct.srcip
      aws_account=%ct.user.accountid)
@@ -123,6 +125,7 @@
     (user=%ct.user
      event=%ct.name
      resource=%ct.request.name
+     request=%ct.request
      region=%ct.region
      source_ip=%ct.srcip
      aws_account=%ct.user.accountid)


### PR DESCRIPTION
## What (stacked on #361 / ADR-006)

Make real-time drift **resource-attributed**. Before this, every real Falco alert
resolved to `resource=<NA>` and tfdrift dropped the drift.

## Root cause (real-machine finding)

`cloudtrail` plugin 0.17.1 does **not** expose the per-service id fields that
`event_mappings.yaml` assumes (`ct.request.instanceid`, `ct.request.groupid`,
`ct.request.bucket`, …). `falco --list` shows it exposes only a curated set
(`ct.request.groupname/subnetid/functionname`, `s3.bucket`) **plus the aggregate
`ct.request`** — the full `requestParameters` JSON. And Falco only emits a field
if the rule's `output:` references it. So the resource id never reached tfdrift.

## Changes

- **rules/terraform_drift.yaml**: emit `%ct.request` in all three rules.
- **pkg/falco/event_parser.go**: `extractResourceID` falls back to parsing the
  `ct.request` JSON, matching the configured candidate keys case-insensitively
  (CloudTrail keys are camelCase — `instanceId`, `groupId`, `bucketName`).
- **pkg/falco/http_receiver.go**: `coerceFields` re-marshals object/array
  output_fields to JSON so `ct.request` survives as valid JSON.
- tests: instanceId/groupId extraction + empty case.

## Verified end-to-end on real AWS

Falco 0.43 + cloudtrail plugin (batch) → `http_output` → tfdrift:

```
⚠️  UNMANAGED RESOURCE DETECTED
   ID: i-0moneyshotdemo01
🔔 Event: ModifyInstanceAttribute
   Resource i-0moneyshotdemo01 (aws_instance) is not found in Terraform state
UNMANAGED RESOURCE: i-0moneyshotdemo01 (aws_instance) ... by ADMIN_OKTA_TEST
```

A resource-attributed drift (was `resource=<NA>`). This is the money-shot's
detection leg.

## Notes / follow-ups

- Depends on #361 (base branch). Both held for re-audit per #360 DoD.
- Nested ids (e.g. CreateNetworkInterface `groupSet.items[].groupId`) still fall
  through; top-level keys cover the common events. Follow-up if needed.
- event_mappings.yaml's stale `ct.request.*` field names are now effectively
  documentation of intent; the JSON fallback is what actually resolves ids.

Refs #362
