### PR TITLE
fix(ui): show detected drifts in the drift list views (#364)

### DIFF
--- a/ui/src/api/hooks/index.ts
+++ b/ui/src/api/hooks/index.ts
@@ -1,6 +1,7 @@
 // Export all API hooks
 export { useGraph, useNodes, useEdges } from './useGraph';
 export { useEvent, useEvents, useUpdateEventStatus } from './useEvents';
+export { useDrifts } from './useDrifts';
 export { useState } from './useState';
 export {
   useNode,

--- a/ui/src/api/hooks/useDrifts.ts
+++ b/ui/src/api/hooks/useDrifts.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { apiClient, type PaginatedResponse } from '../client';
+import { useToastStore } from '../../stores/toastStore';
+import type { DriftAlert } from '../types';
+
+interface DriftsParams {
+  page?: number;
+  limit?: number;
+  severity?: string;
+  provider?: string;
+  search?: string;
+  sort?: string;
+  order?: string;
+}
+
+// useDrifts fetches detected drifts from /api/v1/drifts. The drift list views
+// (Dashboard "Recent Drift Events", Events page) previously read /events, which
+// only holds raw CloudTrail events and is empty — so drifts never appeared even
+// though the KPIs (from /stats) counted them (#364). Polls frequently so a new
+// drift shows up in the feed within a few seconds of detection.
+export const useDrifts = (params?: DriftsParams) => {
+  const addToast = useToastStore((state) => state.addToast);
+
+  const query = useQuery({
+    queryKey: ['drifts', params],
+    queryFn: async () => {
+      const data = await apiClient.getDrifts(params);
+      return data as PaginatedResponse<DriftAlert>;
+    },
+    refetchInterval: 5000,
+  });
+
+  useEffect(() => {
+    if (query.error) {
+      const message = query.error instanceof Error ? query.error.message : 'Failed to fetch drifts';
+      addToast({ type: 'error', title: 'Drifts Error', message });
+    }
+  }, [query.error, addToast]);
+
+  return query;
+};

--- a/ui/src/api/hooks/useStats.ts
+++ b/ui/src/api/hooks/useStats.ts
@@ -11,8 +11,9 @@ export const useStats = () => {
   const query = useQuery({
     queryKey: ['stats'],
     queryFn: async () => (await apiClient.getStats()) as Stats,
-    // Keep the dashboard live without hammering the backend
-    refetchInterval: 30000,
+    // Poll in step with the drift feed (useDrifts) so the KPI counters and the
+    // Recent Drift Events list update together as drifts arrive.
+    refetchInterval: 5000,
   });
 
   useEffect(() => {

--- a/ui/src/pages/DashboardPage.test.tsx
+++ b/ui/src/pages/DashboardPage.test.tsx
@@ -13,7 +13,7 @@ vi.mock('lucide-react', () => ({
 vi.mock('../api/client', () => ({
   apiClient: {
     getStats: vi.fn(),
-    getEvents: vi.fn(),
+    getDrifts: vi.fn(),
   },
 }));
 
@@ -47,13 +47,16 @@ describe('DashboardPage', () => {
       drifts: { total: 3, severity_counts: { critical: 1, high: 1, medium: 1 } },
       events: { total: 15 },
     } as never);
-    vi.mocked(apiClient.getEvents).mockResolvedValue({
+    // The Recent Drift Events feed reads /drifts (#364), not /events.
+    vi.mocked(apiClient.getDrifts).mockResolvedValue({
       data: [
         {
-          id: 'e1',
-          event_name: 'ModifyInstanceAttribute',
+          id: 'd1',
           resource_type: 'aws_instance',
           resource_id: 'i-123',
+          attribute: 'instance_type',
+          old_value: 't3.micro',
+          new_value: 't3.large',
           user_identity: { UserName: 'alice' },
           severity: 'critical',
           timestamp: '2026-07-20T00:00:00Z',
@@ -83,10 +86,11 @@ describe('DashboardPage', () => {
     expect(screen.queryByText(/Coming Soon/i)).not.toBeInTheDocument();
   });
 
-  it('renders a recent drift event with who/what', async () => {
+  it('renders a recent drift with who/what from /drifts', async () => {
     renderPage();
     await waitFor(() => {
-      expect(screen.getByText('ModifyInstanceAttribute')).toBeInTheDocument();
+      // resource + the attribute change + the actor
+      expect(screen.getByText('instance_type: t3.micro → t3.large')).toBeInTheDocument();
       expect(screen.getByText('alice')).toBeInTheDocument();
     });
   });

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -1,18 +1,21 @@
 import { Activity, AlertTriangle, Database, Cloud } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useStats } from '../api/hooks/useStats';
-import { useEvents } from '../api/hooks/useEvents';
-import type { FalcoEvent } from '../api/types';
+import { useDrifts } from '../api/hooks/useDrifts';
+import type { DriftAlert } from '../api/types';
 
 export function DashboardPage() {
   const { data: stats, isLoading: statsLoading } = useStats();
-  const { data: eventsPage, isLoading: eventsLoading } = useEvents({
+  const { data: driftsPage, isLoading: driftsLoading } = useDrifts({
     limit: 8,
     sort: 'timestamp',
     order: 'desc',
   });
 
-  const events = eventsPage?.data ?? [];
+  // Recent Drift Events reads /drifts (detected drifts), not /events (raw
+  // CloudTrail feed, usually empty) — otherwise the list stays empty while the
+  // KPI counts drifts (#364).
+  const drifts = driftsPage?.data ?? [];
 
   // Safe accessors: the stats shape may be partially populated while the
   // backend warms up, so every field falls back to a dash rather than NaN.
@@ -62,9 +65,9 @@ export function DashboardPage() {
           </Link>
         </div>
 
-        {eventsLoading ? (
-          <div className="p-6 text-sm text-slate-400">Loading events…</div>
-        ) : events.length === 0 ? (
+        {driftsLoading ? (
+          <div className="p-6 text-sm text-slate-400">Loading drifts…</div>
+        ) : drifts.length === 0 ? (
           <div className="p-6 text-sm text-slate-400">
             No drift events yet. Changes made outside of Terraform/OpenTofu will appear here.
           </div>
@@ -73,16 +76,16 @@ export function DashboardPage() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="text-left text-xs text-slate-500 border-b border-slate-100">
-                  <th className="px-6 py-2 font-medium">Event</th>
                   <th className="px-6 py-2 font-medium">Resource</th>
+                  <th className="px-6 py-2 font-medium">Change</th>
                   <th className="px-6 py-2 font-medium">User</th>
                   <th className="px-6 py-2 font-medium">Severity</th>
                   <th className="px-6 py-2 font-medium">When</th>
                 </tr>
               </thead>
               <tbody>
-                {events.map((e) => (
-                  <EventRow key={e.id} event={e} />
+                {drifts.map((d, i) => (
+                  <DriftRow key={d.id ? `${d.id}-${i}` : i} drift={d} />
                 ))}
               </tbody>
             </table>
@@ -93,21 +96,35 @@ export function DashboardPage() {
   );
 }
 
-function EventRow({ event }: { event: FalcoEvent }) {
+function DriftRow({ drift }: { drift: DriftAlert }) {
   return (
     <tr className="border-b border-slate-50 last:border-0 hover:bg-slate-50">
-      <td className="px-6 py-3 font-medium text-slate-800">{event.event_name}</td>
+      <td className="px-6 py-3 font-medium text-slate-800">
+        {drift.resource_type || 'resource'}
+        {drift.resource_id ? <span className="text-slate-400"> · {drift.resource_id}</span> : null}
+      </td>
+      <td className="px-6 py-3 text-slate-600">{formatChange(drift)}</td>
       <td className="px-6 py-3 text-slate-600">
-        {event.resource_type}
-        {event.resource_id ? <span className="text-slate-400"> · {event.resource_id}</span> : null}
+        {drift.user_identity?.UserName || drift.user_identity?.ARN || '—'}
       </td>
-      <td className="px-6 py-3 text-slate-600">{event.user_identity?.UserName || '—'}</td>
       <td className="px-6 py-3">
-        <SeverityBadge severity={event.severity} />
+        <SeverityBadge severity={drift.severity} />
       </td>
-      <td className="px-6 py-3 text-slate-500">{formatTime(event.timestamp)}</td>
+      <td className="px-6 py-3 text-slate-500">{formatTime(drift.timestamp)}</td>
     </tr>
   );
+}
+
+// formatChange renders the drift's attribute change: "attr: old → new" when the
+// values are known, else just the attribute label (coarse "resource modified").
+function formatChange(drift: DriftAlert): string {
+  const attr = drift.attribute || 'modified';
+  const oldV = drift.old_value;
+  const newV = drift.new_value;
+  if (newV && newV !== 'null') {
+    return oldV && oldV !== 'null' ? `${attr}: ${oldV} → ${newV}` : `${attr}: ${newV}`;
+  }
+  return attr;
 }
 
 function SeverityBadge({ severity }: { severity: string }) {

--- a/ui/src/pages/EventsPage.tsx
+++ b/ui/src/pages/EventsPage.tsx
@@ -1,56 +1,54 @@
 import { useState, useMemo, useCallback } from 'react';
 import { EventTable } from '../components/events/EventTable';
 import { EventFilters } from '../components/events/EventFilters';
-import { EventDetailPanel } from '../components/events/EventDetailPanel';
-import { useEvents, useUpdateEventStatus } from '../api/hooks/useEvents';
+import { useDrifts } from '../api/hooks/useDrifts';
 import type { DriftFilters, DriftEvent } from '../types/drift';
-import type { FalcoEvent, EventStatus } from '../api/types';
-import { toast } from '../stores/toastStore';
+import type { DriftAlert } from '../api/types';
 
 /**
- * Adapt a FalcoEvent (API shape) to DriftEvent (UI shape) so existing
- * EventTable / EventFilters keep working with the same interface.
+ * Adapt a DriftAlert (API /drifts shape) to DriftEvent (UI shape) so the
+ * existing EventTable / EventFilters keep working. This page reads /drifts
+ * (detected drifts), not /events (raw CloudTrail feed, usually empty) — the
+ * "Drift Events" list must show drifts (#364).
  */
-function apiEventToDriftEvent(e: FalcoEvent): DriftEvent {
+function apiDriftToDriftEvent(d: DriftAlert): DriftEvent {
+  const hasNew = d.new_value && d.new_value !== 'null';
+  const hasOld = d.old_value && d.old_value !== 'null';
   return {
-    id: e.resource_id,
-    timestamp: e.timestamp || new Date().toISOString(),
-    severity: (e.severity as DriftEvent['severity']) || 'medium',
-    provider: (e.provider as DriftEvent['provider']) || 'aws',
-    resourceType: e.resource_type,
-    resourceId: e.resource_id,
-    resourceName: e.resource_id,
+    id: d.id || d.resource_id,
+    timestamp: d.timestamp || new Date().toISOString(),
+    severity: (d.severity as DriftEvent['severity']) || 'medium',
+    provider: 'aws',
+    resourceType: d.resource_type,
+    resourceId: d.resource_id,
+    resourceName: d.resource_name || d.resource_id,
     changeType: 'modified',
-    attribute: e.event_name,
-    oldValue: null,
-    newValue: null,
+    attribute: d.attribute || 'modified',
+    oldValue: hasOld ? d.old_value : null,
+    newValue: hasNew ? d.new_value : null,
     userIdentity: {
-      type: e.user_identity?.Type || '',
-      userName: e.user_identity?.UserName || 'unknown',
-      arn: e.user_identity?.ARN,
-      accountId: e.user_identity?.AccountID,
+      type: d.user_identity?.Type || '',
+      userName: d.user_identity?.UserName || d.user_identity?.ARN || 'unknown',
+      arn: d.user_identity?.ARN,
+      accountId: d.user_identity?.AccountID,
     },
-    region: e.region || '',
+    region: '',
   };
 }
 
 export function EventsPage() {
   const [filters, setFilters] = useState<DriftFilters>({});
   const [selectedDriftEvent, setSelectedDriftEvent] = useState<DriftEvent | null>(null);
-  const [selectedApiEvent, setSelectedApiEvent] = useState<FalcoEvent | null>(null);
 
-  // Fetch real events from API
-  const { data: apiData } = useEvents({
+  // Fetch detected drifts from /api/v1/drifts (#364).
+  const { data: apiData } = useDrifts({
     severity: filters.severity?.[0],
     provider: filters.provider?.[0],
     search: filters.search,
   });
-  const updateStatus = useUpdateEventStatus();
 
-  // Real events from the API only — no mock fallback (the empty state is
-  // itself meaningful: no drift has been detected yet).
-  const apiEvents = useMemo<FalcoEvent[]>(() => apiData?.data || [], [apiData]);
-  const baseEvents = useMemo(() => apiEvents.map(apiEventToDriftEvent), [apiEvents]);
+  const apiDrifts = useMemo<DriftAlert[]>(() => apiData?.data || [], [apiData]);
+  const baseEvents = useMemo(() => apiDrifts.map(apiDriftToDriftEvent), [apiDrifts]);
 
   const filtered = useMemo(() => {
     return baseEvents.filter((evt) => {
@@ -68,64 +66,13 @@ export function EventsPage() {
     });
   }, [baseEvents, filters]);
 
-  // Track selected index for prev/next navigation
-  const selectedIndex = useMemo(() => {
-    if (!selectedDriftEvent) return -1;
-    return filtered.findIndex((e) => e.id === selectedDriftEvent.id);
-  }, [filtered, selectedDriftEvent]);
-
-  const handleEventClick = useCallback(
-    (driftEvt: DriftEvent) => {
-      setSelectedDriftEvent(driftEvt);
-      // Find corresponding API event for the detail panel
-      const apiEvt = apiEvents.find((e) => e.resource_id === driftEvt.id);
-      setSelectedApiEvent(apiEvt || null);
-    },
-    [apiEvents]
-  );
+  const handleEventClick = useCallback((driftEvt: DriftEvent) => {
+    setSelectedDriftEvent(driftEvt);
+  }, []);
 
   const handleClose = useCallback(() => {
     setSelectedDriftEvent(null);
-    setSelectedApiEvent(null);
   }, []);
-
-  const handlePrev = useCallback(() => {
-    if (selectedIndex > 0) {
-      const prev = filtered[selectedIndex - 1];
-      handleEventClick(prev);
-    }
-  }, [selectedIndex, filtered, handleEventClick]);
-
-  const handleNext = useCallback(() => {
-    if (selectedIndex < filtered.length - 1) {
-      const next = filtered[selectedIndex + 1];
-      handleEventClick(next);
-    }
-  }, [selectedIndex, filtered, handleEventClick]);
-
-  const handleStatusChange = useCallback(
-    (id: string, status: EventStatus, reason?: string) => {
-      updateStatus.mutate(
-        { id, status, reason },
-        {
-          onSuccess: () => {
-            const labels: Record<string, string> = {
-              acknowledged: 'Acknowledged',
-              ignored: 'Ignored',
-              resolved: 'Resolved',
-              open: 'Reopened',
-            };
-            toast.success(`Event ${labels[status] || status}`, `Status updated for ${id}`);
-          },
-          onError: () => {
-            toast.error('Status update failed', 'Please try again.');
-          },
-        }
-      );
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [updateStatus, toast]
-  );
 
   return (
     <div className="space-y-4">
@@ -140,23 +87,8 @@ export function EventsPage() {
 
       <EventTable events={filtered} onEventClick={handleEventClick} />
 
-      {/* Detail Panel — uses API event if available, otherwise shows basic info */}
-      {selectedDriftEvent && selectedApiEvent && (
-        <EventDetailPanel
-          event={selectedApiEvent}
-          onClose={handleClose}
-          onStatusChange={handleStatusChange}
-          onPrev={handlePrev}
-          onNext={handleNext}
-          hasPrev={selectedIndex > 0}
-          hasNext={selectedIndex < filtered.length - 1}
-          currentIndex={selectedIndex}
-          totalCount={filtered.length}
-        />
-      )}
-
-      {/* Fallback: simple panel for mock events without API data */}
-      {selectedDriftEvent && !selectedApiEvent && (
+      {/* Detail panel for the selected drift */}
+      {selectedDriftEvent && (
         <div className="fixed inset-y-0 right-0 w-96 bg-white border-l border-slate-200 shadow-xl p-6 overflow-y-auto z-50">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-bold text-slate-900">Event Detail</h2>


### PR DESCRIPTION
## What

The drift list views showed nothing even when a drift was detected: the Dashboard
"Recent Drift Events" and the Events page "Drift Events" table read
`/api/v1/events` (raw CloudTrail feed, usually empty), while the KPI cards read
`/api/v1/stats` (which counts drifts). Result: **"Total Drift Events: 1" next to
"No drift events yet."** (#364).

## Changes

- **useDrifts** hook — `GET /api/v1/drifts` (`DriftAlert[]`), polls every 5s so a
  new drift shows in the feed within seconds.
- **DashboardPage** — "Recent Drift Events" renders drifts: resource, attribute
  change (`old → new`), actor, severity.
- **EventsPage** — "Drift Events" table reads `/drifts` via a `DriftAlert →
  DriftEvent` adapter; detail panel renders from the drift.
- **useStats** — polls every 5s (was 30s) so the KPI counters and the feed update
  in step.
- tests updated to mock `/drifts`.

## Verified on real infra (money-shot)

Real Falco 0.43 → `http_output` (#360) → tfdrift (`ct.request` resource-id, #362)
→ UI. With no page reload, within ~5s of injecting a real `ModifyInstanceAttribute`
drift on a managed `aws_instance`:

- Dashboard KPI **Total Drift Events 0 → 1**
- Recent Drift Events card appears: **aws_instance · i-0uidemo00000001**,
  `(resource modified out-of-band): ModifyInstanceAttribute`, user
  **ADMIN_OKTA_TEST**, severity **medium**.

Frontend-only; independent of the backend PRs but completes the same
real-time-drift story (#360 → #362 → #364).

Fixes #364
