### PR TITLE
fix(detector): re-read Terraform state on an interval (#331)

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -5,6 +5,11 @@
 # a regression test (pkg/config/example_test.go) strict-decodes this file
 # against those structs, so any key that isn't a real field fails CI.
 
+# How often (seconds) to re-read the Terraform state so a long-running detector
+# picks up legitimate `terraform apply`s instead of flagging them as drift.
+# 0 = load once at startup (default). See #331.
+state_refresh_interval: 0
+
 # Cloud Provider Configuration
 providers:
   # AWS Configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,7 +21,13 @@ type Config struct {
 	Remediation   RemediationConfig   `yaml:"remediation"`
 	GitHub        GitHubConfig        `yaml:"github"`
 	Policy        PolicyConfig        `yaml:"policy"`
-	DryRun        bool                `yaml:"-"`
+
+	// StateRefreshIntervalSec re-reads the Terraform state every N seconds so a
+	// long-running detector sees legitimate `terraform apply`s instead of
+	// flagging them as drift forever. 0 (default) = load once at startup (#331).
+	StateRefreshIntervalSec int `yaml:"state_refresh_interval" mapstructure:"state_refresh_interval"`
+
+	DryRun bool `yaml:"-"`
 }
 
 // TelemetryConfig contains OpenTelemetry settings

--- a/pkg/detector/lifecycle.go
+++ b/pkg/detector/lifecycle.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"context"
 	"fmt"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -42,6 +43,16 @@ func (d *Detector) Start(ctx context.Context) error {
 		d.processEvents(ctx)
 	}()
 
+	// Periodically re-read Terraform state so legit applies aren't flagged as
+	// drift forever (#331). Disabled (load-once) when the interval is 0.
+	if d.cfg.StateRefreshIntervalSec > 0 {
+		d.wg.Add(1)
+		go func() {
+			defer d.wg.Done()
+			d.refreshStatePeriodically(ctx)
+		}()
+	}
+
 	// Wait for context cancellation
 	<-ctx.Done()
 
@@ -49,6 +60,40 @@ func (d *Detector) Start(ctx context.Context) error {
 	d.wg.Wait()
 
 	return nil
+}
+
+// refreshStatePeriodically re-reads every provider's Terraform state on a timer
+// and rebuilds the graph, so a running detector picks up legitimate applies
+// instead of comparing against the startup snapshot forever (#331).
+func (d *Detector) refreshStatePeriodically(ctx context.Context) {
+	interval := time.Duration(d.cfg.StateRefreshIntervalSec) * time.Second
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	log.Infof("Terraform state refresh enabled: every %s", interval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.refreshAllState(ctx)
+		}
+	}
+}
+
+// refreshAllState re-reads every provider's state once and rebuilds the graph.
+// Extracted from the ticker loop so the refresh is unit-testable without waiting
+// on wall-clock time (#331).
+func (d *Detector) refreshAllState(ctx context.Context) {
+	for name, sm := range d.stateManagers {
+		if err := sm.Refresh(ctx); err != nil {
+			log.Warnf("State refresh failed for provider %s: %v", name, err)
+		}
+	}
+	if d.graphStore != nil {
+		d.graphStore.RebuildGraphDB()
+	}
+	log.Debug("Terraform state refreshed")
 }
 
 // startCollectors starts the Falco event source. With the HTTP transport

--- a/pkg/detector/state_refresh_test.go
+++ b/pkg/detector/state_refresh_test.go
@@ -1,0 +1,68 @@
+package detector
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keitahigaki/tfdrift-falco/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const stateOneResource = `{
+  "version": 4, "terraform_version": "1.9.0", "serial": 1, "lineage": "l", "outputs": {},
+  "resources": [
+    { "mode": "managed", "type": "aws_instance", "name": "a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [ { "attributes": { "id": "i-aaa", "instance_type": "t3.micro" } } ] }
+  ]
+}`
+
+const stateTwoResources = `{
+  "version": 4, "terraform_version": "1.9.0", "serial": 2, "lineage": "l", "outputs": {},
+  "resources": [
+    { "mode": "managed", "type": "aws_instance", "name": "a",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [ { "attributes": { "id": "i-aaa", "instance_type": "t3.micro" } } ] },
+    { "mode": "managed", "type": "aws_instance", "name": "b",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [ { "attributes": { "id": "i-bbb", "instance_type": "t3.small" } } ] }
+  ]
+}`
+
+// TestRefreshAllState_PicksUpAppliedChanges proves the fix for #331: after a
+// legitimate `terraform apply` adds a resource to the state file, a running
+// detector that refreshes sees it — instead of comparing against the startup
+// snapshot forever (and flagging the new resource as unmanaged drift).
+func TestRefreshAllState_PicksUpAppliedChanges(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "terraform.tfstate")
+	require.NoError(t, os.WriteFile(statePath, []byte(stateOneResource), 0o600))
+
+	cfg := &config.Config{}
+	cfg.Providers.AWS.Enabled = true
+	cfg.Providers.AWS.Regions = []string{"ap-northeast-1"}
+	cfg.Providers.AWS.State.Backend = "local"
+	cfg.Providers.AWS.State.LocalPath = statePath
+	cfg.Falco.Enabled = false
+
+	det, err := New(cfg)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, det.GetStateManager().Load(ctx))
+	require.Equal(t, 1, det.GetStateManager().ResourceCount())
+
+	// Simulate a `terraform apply` that adds a second managed resource.
+	require.NoError(t, os.WriteFile(statePath, []byte(stateTwoResources), 0o600))
+
+	// Without a refresh the detector would still see only 1 resource.
+	det.refreshAllState(ctx)
+
+	assert.Equal(t, 2, det.GetStateManager().ResourceCount(),
+		"refresh must re-read state so applied changes are visible (#331)")
+	_, exists := det.GetStateManager().GetResource("i-bbb")
+	assert.True(t, exists, "the newly applied resource must be known after refresh")
+}


### PR DESCRIPTION
State was loaded once at startup and never refreshed — `Refresh()` had zero callers, `state_refresh_interval` was a ghost key. A legitimate `terraform apply` on a long-running detector stayed invisible until restart (flagged as unmanaged drift forever).

- config: real `state_refresh_interval` (seconds; 0=load once default), documented in config.yaml.example (strict-decoded in CI).
- detector: when >0, a goroutine re-reads every provider state on the interval + rebuilds the graph (`refreshAllState`, extracted for unit-testability).
- test: after the state file gains a resource, `refreshAllState` makes it visible (1→2, new id resolvable).

Fixes #331