### PR TITLE
fix(aws): SG rule comparison + scope missing + deref subnet bools (#338 comparison-layer)

### DIFF
--- a/pkg/aws/comparator.go
+++ b/pkg/aws/comparator.go
@@ -2,11 +2,27 @@ package aws
 
 import (
 	"reflect"
+	"sort"
 
 	"github.com/keitahigaki/tfdrift-falco/pkg/comparator"
 	"github.com/keitahigaki/tfdrift-falco/pkg/terraform"
 	"github.com/keitahigaki/tfdrift-falco/pkg/types"
 )
+
+// discoverableResourceTypes is the set of AWS resource types DiscoverAll actually
+// queries. A Terraform resource is only reported as `missing` when its type is in
+// this set — otherwise "not found in the cloud scan" just means "we never scanned
+// that type", which was being mis-reported as drift and inflating `missing` (#338).
+var discoverableResourceTypes = map[string]bool{
+	"aws_vpc":                           true,
+	"aws_subnet":                        true,
+	"aws_security_group":                true,
+	"aws_instance":                      true,
+	"aws_db_instance":                   true,
+	"aws_eks_cluster":                   true,
+	"aws_elasticache_replication_group": true,
+	"aws_lb":                            true,
+}
 
 // CompareStateWithActual compares Terraform state with actual AWS resources
 // and returns the differences (unmanaged, missing, and modified resources)
@@ -66,6 +82,18 @@ func CompareStateWithActual(tfResources []*terraform.Resource, awsResources []*t
 
 	result := comparator.CompareResources(config, convertTFResources(tfResources), convertCloudResources(awsResources))
 	result.Provider = "aws"
+
+	// Scope `missing` to types discovery actually scans. A resource of an
+	// unscanned type has no cloud match not because it was deleted but because we
+	// never looked — reporting it as missing is a false positive (#338).
+	scoped := result.MissingResources[:0]
+	for _, m := range result.MissingResources {
+		if m != nil && discoverableResourceTypes[m.Type] {
+			scoped = append(scoped, m)
+		}
+	}
+	result.MissingResources = scoped
+
 	return result
 }
 
@@ -127,6 +155,29 @@ func compareResourceAttributes(tfRes *terraform.Resource, awsRes *types.Discover
 				TerraformValue: tfValue,
 				ActualValue:    awsValue,
 			})
+		}
+	}
+
+	// Security-group rules: the AWS side is a pre-canonicalized rule set (from
+	// discovery); canonicalize the Terraform blocks the same way and compare as
+	// unordered sets, so an added/removed ingress/egress rule is caught (#338).
+	if tfRes.Type == "aws_security_group" {
+		for _, field := range []string{"ingress", "egress"} {
+			tfRules := canonicalizeTFRules(tfRes.Attributes[field])
+			awsRules := toStringSliceVal(awsRes.Attributes[field])
+			sort.Strings(awsRules)
+			// Treat nil and empty as equal (a missing key is not drift); only a
+			// genuine set difference counts.
+			if len(tfRules) == 0 && len(awsRules) == 0 {
+				continue
+			}
+			if !reflect.DeepEqual(tfRules, awsRules) {
+				differences = append(differences, &types.FieldDiff{
+					Field:          field,
+					TerraformValue: tfRules,
+					ActualValue:    awsRules,
+				})
+			}
 		}
 	}
 

--- a/pkg/aws/discovery.go
+++ b/pkg/aws/discovery.go
@@ -206,8 +206,8 @@ func (d *DiscoveryClient) discoverSubnets(ctx context.Context) ([]*DiscoveredRes
 				"vpc_id":                          aws.ToString(subnet.VpcId),
 				"cidr_block":                      aws.ToString(subnet.CidrBlock),
 				"availability_zone":               aws.ToString(subnet.AvailabilityZone),
-				"map_public_ip_on_launch":         subnet.MapPublicIpOnLaunch,
-				"assign_ipv6_address_on_creation": subnet.AssignIpv6AddressOnCreation,
+				"map_public_ip_on_launch":         aws.ToBool(subnet.MapPublicIpOnLaunch),
+				"assign_ipv6_address_on_creation": aws.ToBool(subnet.AssignIpv6AddressOnCreation),
 			},
 			Tags: tags,
 		})
@@ -235,6 +235,9 @@ func (d *DiscoveryClient) discoverSecurityGroups(ctx context.Context) ([]*Discov
 				"vpc_id":      aws.ToString(sg.VpcId),
 				"description": aws.ToString(sg.Description),
 				"name":        aws.ToString(sg.GroupName),
+				// Canonical rule sets so ingress/egress drift is detectable (#338).
+				"ingress": canonicalizeAWSPermissions(sg.IpPermissions),
+				"egress":  canonicalizeAWSPermissions(sg.IpPermissionsEgress),
 			},
 			Tags: tags,
 		})

--- a/pkg/aws/live_verify_test.go
+++ b/pkg/aws/live_verify_test.go
@@ -1,0 +1,93 @@
+//go:build liveaws
+
+// Live-AWS re-verification of the #338 comparison-layer fixes. Runs only with
+// `-tags liveaws` against a real account (never in normal CI). It confirms, on
+// real infrastructure, that: (1) security-group ingress rules are discovered and
+// canonicalized, (2) a rule present in the cloud but not in state is reported as
+// ingress drift, (3) no attribute leaks a pointer address, and (4) `missing` is
+// scoped to scanned types.
+package aws
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/keitahigaki/tfdrift-falco/pkg/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLive_ComparatorCorrectness(t *testing.T) {
+	region := envOr("TFDRIFT_LIVE_REGION", "ap-northeast-1")
+	sgID := envOr("TFDRIFT_LIVE_SG", "sg-056b65b187cd8ece3")
+
+	ctx := context.Background()
+	dc, err := NewDiscoveryClient(ctx, region)
+	require.NoError(t, err)
+
+	all, err := dc.DiscoverAll(ctx)
+	require.NoError(t, err)
+	t.Logf("discovered %d resources in %s", len(all), region)
+
+	// 1) The lab SG is discovered and its ingress rules are populated as a
+	//    canonical string set (the gap #338 fixed).
+	var sg *DiscoveredResource
+	for _, r := range all {
+		if r.ID == sgID {
+			sg = r
+		}
+	}
+	require.NotNil(t, sg, "lab SG %s must be discovered", sgID)
+	ingress := toStringSliceVal(sg.Attributes["ingress"])
+	require.NotEmpty(t, ingress, "SG ingress rules must be discovered (was silently dropped)")
+	t.Logf("SG %s ingress canonical rules: %v", sgID, ingress)
+
+	// 2) Pointer-leak regression: no discovered attribute renders as a 0x address.
+	for _, r := range all {
+		for k, v := range r.Attributes {
+			assert.NotContains(t, fmt.Sprintf("%v", v), "0x",
+				"attribute %s.%s leaks a pointer address", r.ID, k)
+		}
+	}
+
+	// 3) State with no ingress vs a cloud SG that HAS rules → ingress drift.
+	tfSG := &terraform.Resource{
+		Type: "aws_security_group", Name: "lab",
+		Attributes: map[string]interface{}{
+			"id":          sgID,
+			"vpc_id":      sg.Attributes["vpc_id"],
+			"description": sg.Attributes["description"],
+			"name":        sg.Attributes["name"],
+			// ingress intentionally omitted → cloud rules are drift
+		},
+	}
+	res := CompareStateWithActual([]*terraform.Resource{tfSG}, all)
+	var ingressDrift bool
+	for _, m := range res.ModifiedResources {
+		if m.ResourceID == sgID {
+			for _, d := range m.Differences {
+				if d.Field == "ingress" {
+					ingressDrift = true
+					t.Logf("ingress drift reported: tf=%v actual=%v", d.TerraformValue, d.ActualValue)
+				}
+			}
+		}
+	}
+	assert.True(t, ingressDrift, "cloud SG rules absent from state must be reported as ingress drift")
+
+	// 4) missing scoping: an unscanned type is never reported missing.
+	tfIAM := &terraform.Resource{Type: "aws_iam_role", Name: "x", Attributes: map[string]interface{}{"id": "role-not-scanned"}}
+	res2 := CompareStateWithActual([]*terraform.Resource{tfIAM}, all)
+	for _, m := range res2.MissingResources {
+		assert.NotEqual(t, "aws_iam_role", m.Type, "an unscanned type must not be reported missing")
+	}
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}

--- a/pkg/aws/sg_rules.go
+++ b/pkg/aws/sg_rules.go
@@ -1,0 +1,136 @@
+package aws
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// Security-group rule comparison (#338 / #362).
+//
+// A security group's ingress/egress rules are the highest-value drift to catch
+// (AuthorizeSecurityGroupIngress is the demo's headline event), but the AWS API
+// shape (IpPermission) and the Terraform-state shape (ingress blocks) differ, and
+// rule order is not significant. We normalize both sides to a *sorted set of
+// canonical rule strings* so they can be compared with a plain DeepEqual without
+// false positives from ordering or representation.
+//
+// Canonical form: "proto|from|to|cidrs|ipv6|sgrefs" with each list sorted.
+
+func canonicalRuleString(proto string, from, to int64, cidrs, ipv6, sgRefs []string) string {
+	sort.Strings(cidrs)
+	sort.Strings(ipv6)
+	sort.Strings(sgRefs)
+	return fmt.Sprintf("%s|%d|%d|%s|%s|%s",
+		normalizeProto(proto), from, to,
+		strings.Join(cidrs, ","), strings.Join(ipv6, ","), strings.Join(sgRefs, ","))
+}
+
+// normalizeProto folds Terraform's "all" onto AWS's "-1" so the two agree.
+func normalizeProto(p string) string {
+	p = strings.ToLower(strings.TrimSpace(p))
+	if p == "all" || p == "" {
+		return "-1"
+	}
+	return p
+}
+
+// canonicalizeAWSPermissions normalizes AWS IpPermissions into a sorted canonical
+// rule set. Ports are 0 when absent (e.g. protocol -1 / all).
+func canonicalizeAWSPermissions(perms []ec2Types.IpPermission) []string {
+	out := make([]string, 0, len(perms))
+	for _, p := range perms {
+		var from, to int64
+		if p.FromPort != nil {
+			from = int64(*p.FromPort)
+		}
+		if p.ToPort != nil {
+			to = int64(*p.ToPort)
+		}
+		var cidrs, ipv6, sgRefs []string
+		for _, r := range p.IpRanges {
+			cidrs = append(cidrs, aws.ToString(r.CidrIp))
+		}
+		for _, r := range p.Ipv6Ranges {
+			ipv6 = append(ipv6, aws.ToString(r.CidrIpv6))
+		}
+		for _, g := range p.UserIdGroupPairs {
+			sgRefs = append(sgRefs, aws.ToString(g.GroupId))
+		}
+		out = append(out, canonicalRuleString(aws.ToString(p.IpProtocol), from, to, cidrs, ipv6, sgRefs))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// canonicalizeTFRules normalizes Terraform-state ingress/egress blocks (a list of
+// {from_port,to_port,protocol,cidr_blocks,...}) into the same sorted canonical set.
+func canonicalizeTFRules(blocks interface{}) []string {
+	out := []string{}
+	for _, b := range toSliceOfMaps(blocks) {
+		out = append(out, canonicalRuleString(
+			toStringVal(b["protocol"]),
+			toInt64Val(b["from_port"]),
+			toInt64Val(b["to_port"]),
+			toStringSliceVal(b["cidr_blocks"]),
+			toStringSliceVal(b["ipv6_cidr_blocks"]),
+			toStringSliceVal(b["security_groups"]),
+		))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// --- small, total conversion helpers (Terraform state values are untyped) ---
+
+func toSliceOfMaps(v interface{}) []map[string]interface{} {
+	var out []map[string]interface{}
+	switch s := v.(type) {
+	case []interface{}:
+		for _, e := range s {
+			if m, ok := e.(map[string]interface{}); ok {
+				out = append(out, m)
+			}
+		}
+	case []map[string]interface{}:
+		out = append(out, s...)
+	}
+	return out
+}
+
+func toStringVal(v interface{}) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func toInt64Val(v interface{}) int64 {
+	switch n := v.(type) {
+	case int:
+		return int64(n)
+	case int64:
+		return n
+	case float64:
+		return int64(n)
+	}
+	return 0
+}
+
+func toStringSliceVal(v interface{}) []string {
+	var out []string
+	switch s := v.(type) {
+	case []interface{}:
+		for _, e := range s {
+			if str, ok := e.(string); ok {
+				out = append(out, str)
+			}
+		}
+	case []string:
+		out = append(out, s...)
+	}
+	return out
+}

--- a/pkg/aws/sg_rules_test.go
+++ b/pkg/aws/sg_rules_test.go
@@ -1,0 +1,128 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/keitahigaki/tfdrift-falco/pkg/terraform"
+	"github.com/keitahigaki/tfdrift-falco/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func awsTCP(from, to int32, cidr string) ec2Types.IpPermission {
+	return ec2Types.IpPermission{
+		IpProtocol: aws.String("tcp"),
+		FromPort:   aws.Int32(from),
+		ToPort:     aws.Int32(to),
+		IpRanges:   []ec2Types.IpRange{{CidrIp: aws.String(cidr)}},
+	}
+}
+
+// The AWS API shape and the Terraform-state shape for the same rule must produce
+// the same canonical string, so an unchanged SG shows no drift.
+func TestCanonicalize_AWSAndTF_AgreeOnSameRule(t *testing.T) {
+	awsRules := canonicalizeAWSPermissions([]ec2Types.IpPermission{awsTCP(443, 443, "10.0.0.0/8")})
+	tfRules := canonicalizeTFRules([]interface{}{
+		map[string]interface{}{
+			"protocol": "tcp", "from_port": float64(443), "to_port": float64(443),
+			"cidr_blocks": []interface{}{"10.0.0.0/8"},
+		},
+	})
+	assert.Equal(t, awsRules, tfRules)
+	assert.Len(t, awsRules, 1)
+}
+
+// Rule order must not matter (sets, not lists).
+func TestCanonicalize_OrderInsensitive(t *testing.T) {
+	a := canonicalizeAWSPermissions([]ec2Types.IpPermission{awsTCP(80, 80, "0.0.0.0/0"), awsTCP(443, 443, "0.0.0.0/0")})
+	b := canonicalizeAWSPermissions([]ec2Types.IpPermission{awsTCP(443, 443, "0.0.0.0/0"), awsTCP(80, 80, "0.0.0.0/0")})
+	assert.Equal(t, a, b)
+}
+
+// "all" (Terraform) and "-1" (AWS) are the same protocol.
+func TestNormalizeProto_AllEqualsMinusOne(t *testing.T) {
+	assert.Equal(t, "-1", normalizeProto("all"))
+	assert.Equal(t, "-1", normalizeProto("-1"))
+	assert.Equal(t, "tcp", normalizeProto("TCP"))
+}
+
+// The money-shot drift: an ingress rule present in the cloud but not in state
+// must surface as an `ingress` field diff.
+func TestCompareSG_IngressDriftDetected(t *testing.T) {
+	tfRes := &terraform.Resource{
+		Type: "aws_security_group", Name: "web",
+		Attributes: map[string]interface{}{
+			"id":     "sg-1",
+			"vpc_id": "vpc-1", "description": "web", "name": "web",
+			"ingress": []interface{}{
+				map[string]interface{}{"protocol": "tcp", "from_port": float64(443), "to_port": float64(443), "cidr_blocks": []interface{}{"10.0.0.0/8"}},
+			},
+		},
+	}
+	awsRes := &types.DiscoveredResource{
+		Type: "aws_security_group", ID: "sg-1",
+		Attributes: map[string]interface{}{
+			"vpc_id": "vpc-1", "description": "web", "name": "web",
+			// drift: an extra rule opened to the world (8443 from 203.0.113.7/32)
+			"ingress": canonicalizeAWSPermissions([]ec2Types.IpPermission{
+				awsTCP(443, 443, "10.0.0.0/8"),
+				awsTCP(8443, 8443, "203.0.113.7/32"),
+			}),
+			"egress": []string{},
+		},
+	}
+
+	diffs := compareResourceAttributes(tfRes, awsRes)
+	var found bool
+	for _, d := range diffs {
+		if d.Field == "ingress" {
+			found = true
+		}
+	}
+	assert.True(t, found, "an added ingress rule must be reported as ingress drift")
+}
+
+// No drift when state and cloud carry the same rule set (no false positive).
+func TestCompareSG_NoDriftWhenRulesMatch(t *testing.T) {
+	rules := []ec2Types.IpPermission{awsTCP(443, 443, "10.0.0.0/8")}
+	tfRes := &terraform.Resource{
+		Type: "aws_security_group", Name: "web",
+		Attributes: map[string]interface{}{
+			"id": "sg-1", "vpc_id": "vpc-1", "description": "web", "name": "web",
+			"ingress": []interface{}{
+				map[string]interface{}{"protocol": "tcp", "from_port": float64(443), "to_port": float64(443), "cidr_blocks": []interface{}{"10.0.0.0/8"}},
+			},
+		},
+	}
+	awsRes := &types.DiscoveredResource{
+		Type: "aws_security_group", ID: "sg-1",
+		Attributes: map[string]interface{}{
+			"vpc_id": "vpc-1", "description": "web", "name": "web",
+			"ingress": canonicalizeAWSPermissions(rules),
+			"egress":  []string{},
+		},
+	}
+	for _, d := range compareResourceAttributes(tfRes, awsRes) {
+		assert.NotEqual(t, "ingress", d.Field, "matching rule sets must not report ingress drift")
+	}
+}
+
+// `missing` must be scoped to discoverable types: a tf resource of an unscanned
+// type (e.g. aws_iam_role) is not "missing", just not scanned (#338).
+func TestCompareStateWithActual_MissingScopedToDiscoverableTypes(t *testing.T) {
+	tf := []*terraform.Resource{
+		{Type: "aws_iam_role", Name: "r", Attributes: map[string]interface{}{"id": "role-x"}},    // unscanned type
+		{Type: "aws_instance", Name: "i", Attributes: map[string]interface{}{"id": "i-deleted"}}, // scanned + gone = real missing
+	}
+	// Cloud discovery found nothing (both absent), but only the aws_instance
+	// should be reported missing.
+	result := CompareStateWithActual(tf, nil)
+
+	var types_ []string
+	for _, m := range result.MissingResources {
+		types_ = append(types_, m.Type)
+	}
+	assert.Contains(t, types_, "aws_instance", "a deleted instance is genuinely missing")
+	assert.NotContains(t, types_, "aws_iam_role", "an unscanned type must not be reported missing")
+}


### PR DESCRIPTION
Re-audit of the `tfdrift scan` comparison layer (#338) found three correctness gaps in the **shared comparator** (used by both `scan` and `GET /api/v1/discovery/drift`). #338 itself reuses this comparator unchanged, so these fixes are what make it merge-ready. All AWS-free reproducible + unit-tested; **live re-verify still pending** (lab AWS session expired).

### Fixes
1. **SG ingress/egress never compared** — `getComparableFields("aws_security_group")` was `[vpc_id, description, name]` only, so `scan` silently missed security-group rule drift (the demo's headline `AuthorizeSecurityGroupIngress`). New `sg_rules.go` canonicalizes both AWS `IpPermissions` and Terraform ingress/egress blocks into a sorted rule set and compares them as unordered sets (order-insensitive, `all`↔`-1` folded, `nil`==empty). Discovery now populates `ingress`/`egress`.
2. **`missing` not scoped to scanned types** — a tf resource of a type discovery never queries (IAM role, Lambda, …) was reported `missing`. Now scoped to `discoverableResourceTypes`, so `missing` = "scanned and gone".
3. **Pointer-address leak** — subnet `map_public_ip_on_launch` / `assign_ipv6_address_on_creation` were raw `*bool` (rendered as `0x…`); deref via `aws.ToBool`.

### Tests
AWS/TF canonical agreement, order-insensitivity, proto folding, ingress drift detected, no false positive on matching sets, missing-scoping. Full `pkg/aws` + `pkg/comparator` green.

### Merge policy
Detection correctness → **hold for live-AWS re-verify** (baseline drift, SG-rule change, multi-region, global dedup) before merge, per ADR-0013. Unblocks #338.

Refs #338