### PR TITLE
ci: don't fail dependabot PRs when the repo disallows auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,7 +19,16 @@ jobs:
 
       - name: Auto-merge patch and minor updates
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          if gh pr merge --auto --squash "$PR_URL" 2>merge-err.log; then
+            exit 0
+          fi
+          if grep -q 'enablePullRequestAutoMerge' merge-err.log; then
+            echo "::notice title=auto-merge unavailable::This repository has auto-merge disabled (Settings -> General -> Allow auto-merge). Leaving the PR open for a human to merge."
+            exit 0
+          fi
+          cat merge-err.log >&2
+          exit 1
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`gh pr merge --auto` exits 1 with `GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)` because **Settings → General → Allow auto-merge** is off. A missing repository capability was reporting as a failed build on every dependabot PR, which hides real failures.

That specific error now becomes a `::notice::` and the job exits 0; **any other merge failure still fails the job**, so this doesn't paper over genuine problems. The PR is left open for a human to merge — which is what happens today regardless.

Enabling the repo setting is still the better end state (dependabot patch/minor PRs would then merge themselves); this just stops the red check.

Fixes #386