### PR TITLE
fix(vcs): emit tree entries in a stable order (flaky TestCreateTree_Success)

### DIFF
--- a/pkg/vcs/github.go
+++ b/pkg/vcs/github.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"time"
 )
 
@@ -245,14 +246,22 @@ func (c *GitHubClient) commitFiles(ctx context.Context, branchName, commitMsg st
 func (c *GitHubClient) createTree(ctx context.Context, files map[string]string, baseTreeSHA string) (string, error) {
 	url := fmt.Sprintf("%s/repos/%s/%s/git/trees", c.apiBase, c.owner, c.repo)
 
-	// Convert files to tree items
+	// Convert files to tree items, ordered by path. Ranging over the map
+	// directly would emit the entries in Go's randomized iteration order, so
+	// the same set of files produced a different request body on every call.
+	paths := make([]string, 0, len(files))
+	for path := range files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
 	treeItems := make([]treeItem, 0, len(files))
-	for path, content := range files {
+	for _, path := range paths {
 		treeItems = append(treeItems, treeItem{
 			Path:    path,
 			Mode:    "100644",
 			Type:    "blob",
-			Content: content,
+			Content: files[path],
 		})
 	}
 

--- a/pkg/vcs/github_extended_test.go
+++ b/pkg/vcs/github_extended_test.go
@@ -116,10 +116,15 @@ func TestCreateTree_Success(t *testing.T) {
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
+			// createTree orders entries by path, so this is a contract, not
+			// a coincidence of Go's map iteration order.
 			assert.Len(t, req.Tree, 2)
 			assert.Equal(t, "file1.txt", req.Tree[0].Path)
+			assert.Equal(t, "content1", req.Tree[0].Content)
 			assert.Equal(t, "100644", req.Tree[0].Mode)
 			assert.Equal(t, "blob", req.Tree[0].Type)
+			assert.Equal(t, "file2.txt", req.Tree[1].Path)
+			assert.Equal(t, "content2", req.Tree[1].Content)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(treeResponse{SHA: "tree123"})


### PR DESCRIPTION
`createTree` (pkg/vcs/github.go:245) ranged over its `files` map directly, so the GitHub tree request carried entries in Go's randomized iteration order.

Two consequences:

1. **`TestCreateTree_Success` failed ~50% of runs on main.** Reproduced on `origin/main`: `go test ./pkg/vcs/ -run TestCreateTree_Success -count=3` → `expected: "file1.txt" / actual: "file2.txt"`. It surfaced as a "Backend fail" on an unrelated dependabot bump (#379), which is how a flaky test on main costs more than its own suite — it makes every PR's CI unreadable.
2. **The same input produced a different request body every call.** For a project built on "same input → same output", a remediation PR payload with nondeterministic ordering is the wrong behaviour.

Sort paths before building `treeItems`; assert both entries in the test so the ordering is a tested contract, not luck.

Verified locally: `go test ./pkg/vcs/ -count=4` green.

Fixes #388