### PR TITLE
fix(ui): keep drift feed live when tab unfocused (demo reliability)

### DIFF
--- a/ui/src/api/hooks/useDrifts.ts
+++ b/ui/src/api/hooks/useDrifts.ts
@@ -29,6 +29,7 @@ export const useDrifts = (params?: DriftsParams) => {
       return data as PaginatedResponse<DriftAlert>;
     },
     refetchInterval: 5000,
+    refetchIntervalInBackground: true,
   });
 
   useEffect(() => {

--- a/ui/src/api/hooks/useStats.ts
+++ b/ui/src/api/hooks/useStats.ts
@@ -14,6 +14,7 @@ export const useStats = () => {
     // Poll in step with the drift feed (useDrifts) so the KPI counters and the
     // Recent Drift Events list update together as drifts arrive.
     refetchInterval: 5000,
+    refetchIntervalInBackground: true,
   });
 
   useEffect(() => {


### PR DESCRIPTION
React Query pauses `refetchInterval` for unfocused tabs, so the Dashboard drift feed/KPIs only updated on reload/refocus during a demo. Set `refetchIntervalInBackground: true` on `useDrifts` + `useStats` so a drift appears within ~5s regardless of focus. Verified: POST a Falco `http_output` alert → card appears with no reload. De-risks the OSS Summit live demo.