### PR TITLE
demo: turnkey OSS Summit money-shot runner (real-time + scan)

### DIFF
--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,0 +1,8 @@
+# runtime artifacts produced by run.sh / scan.sh
+.tfdrift
+.backend.log
+.backend.pid
+.ui.log
+.ui.pid
+.config.run.yaml
+.scan.run.yaml

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,66 @@
+# TFDrift-Falco — live demo runner (OSS Summit money-shot)
+
+A turnkey, low-risk demo of the core value: **a change made outside Terraform is
+caught by TFDrift in real time, with who / what / when** — plus a one-shot
+state-vs-cloud reconcile (`tfdrift scan`).
+
+## Why it's built this way
+
+The real-time act is **driven by the exact JSON Falco 0.43 emits over
+`http_output`** (ADR-006) rather than a live cloud change, so it is deterministic
+and needs no AWS session, no Falco container, and no S3 delivery latency — the
+things most likely to fail on stage. It still exercises the real path:
+receiver → parser → detector → broadcaster → UI. The `scan` act is genuinely live
+against AWS (a fresh `okta-aws-cli` session).
+
+## Prerequisites
+
+- Go + Node/npm (repo already builds).
+- For Act 3 only: a valid AWS session — `okta-aws-cli web … --profile draios-dev-developer`.
+
+## Run it
+
+```bash
+bash demo/run.sh                 # build + start backend (:8080) + UI (:5173)
+# open http://localhost:5173  (keep the tab visible)
+```
+
+### Act 2 — real-time detection (no AWS)
+```bash
+bash demo/trigger-realtime.sh
+```
+Within ~5s a drift card appears on the Dashboard:
+`aws_instance i-0demoweb0000001 — ModifyInstanceAttribute — alice@corp.example — medium`.
+(The feed auto-refreshes even if the tab isn't focused.)
+
+### Act 3 — one-shot reconcile (live AWS)
+```bash
+bash demo/scan.sh
+```
+Prints `Drift detected: … modified=1` with the lab bastion SG's ingress/egress
+rule drift (rules present in the cloud but not in state).
+
+### Teardown
+```bash
+bash demo/teardown.sh
+```
+
+## Suggested 3-act narration (~5 min)
+
+1. **The problem** (30s): someone changes a prod resource in the Console — a
+   `terraform plan` won't notice until the next run.
+2. **Real-time** (90s): run `trigger-realtime.sh`, switch to the UI, the card is
+   already there — point at *who / what / when*.
+3. **Reconcile** (60s): run `scan.sh` — the full state-vs-cloud diff, including
+   security-group rule drift.
+
+## Backup (record before the talk)
+
+Record a screencast of the full **real cloud → Falco → TFDrift → UI** flow while
+your AWS session is fresh, and keep it ready in case anything fails live.
+
+## Honest framing
+
+Continuous delivery uses Falco `http_output` → the TFDrift receiver. Production
+continuous ingestion (periodic CloudTrail pickup) is tracked in #360; the demo
+path and the AWS-free CI E2E (#365) both prove the pipeline.

--- a/demo/config.yaml
+++ b/demo/config.yaml
@@ -1,0 +1,10 @@
+# Demo backend config. State path is rewritten to an absolute path by run.sh.
+providers:
+  aws:
+    enabled: true
+    regions: ["ap-northeast-1"]
+    state: {backend: "local", local_path: "REPLACED_BY_RUN_SH"}
+falco:
+  enabled: true
+  transport: "http"   # ADR-006: Falco http_output → this API server
+logging: {level: "info"}

--- a/demo/run.sh
+++ b/demo/run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# One-command demo bring-up for the OSS Summit money-shot: builds tfdrift, starts
+# the API backend (Falco http transport) + the React UI, then returns. Run it
+# once before the talk (first build downloads deps and can take ~1min).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+API_PORT="${API_PORT:-8080}"
+
+sed "s#REPLACED_BY_RUN_SH#$HERE/state.tfstate#" "$HERE/config.yaml" > "$HERE/.config.run.yaml"
+
+echo "▶ building tfdrift…"
+( cd "$ROOT" && go build -o "$HERE/.tfdrift" ./cmd/tfdrift )
+
+echo "▶ starting backend on :$API_PORT …"
+nohup "$HERE/.tfdrift" --server --api-port "$API_PORT" --config "$HERE/.config.run.yaml" > "$HERE/.backend.log" 2>&1 &
+echo $! > "$HERE/.backend.pid"; disown || true
+for _ in 1 2 3 4 5 6 7 8; do curl -sf "http://127.0.0.1:$API_PORT/health" >/dev/null 2>&1 && break; sleep 1; done
+curl -sf "http://127.0.0.1:$API_PORT/health" >/dev/null 2>&1 && echo "  backend: healthy" || { echo "  backend FAILED — see $HERE/.backend.log"; exit 1; }
+
+echo "▶ starting UI (Vite) on :5173 …"
+( cd "$ROOT/ui" && nohup npm run dev -- --port 5173 --strictPort > "$HERE/.ui.log" 2>&1 & echo $! > "$HERE/.ui.pid"; disown || true )
+
+cat <<MSG
+
+✅ Demo up. Open the UI and keep the tab visible:
+     UI:   http://localhost:5173
+     API:  http://127.0.0.1:$API_PORT
+
+   Act 2 (real-time, no AWS):  bash "$HERE/trigger-realtime.sh"
+   Act 3 (scan, needs AWS):    bash "$HERE/scan.sh"
+   Teardown:                   bash "$HERE/teardown.sh"
+MSG

--- a/demo/scan-config.yaml
+++ b/demo/scan-config.yaml
@@ -1,0 +1,8 @@
+# State path rewritten to an absolute path by scan.sh.
+providers:
+  aws:
+    enabled: true
+    regions: ["ap-northeast-1"]
+    state: {backend: "local", local_path: "REPLACED_BY_SCAN_SH"}
+falco: {enabled: false}
+logging: {level: "warn"}

--- a/demo/scan-state.tfstate
+++ b/demo/scan-state.tfstate
@@ -1,0 +1,4 @@
+{"version":4,"terraform_version":"1.9.0","serial":1,"lineage":"demo","outputs":{},
+ "resources":[{"mode":"managed","type":"aws_security_group","name":"bastion",
+   "provider":"provider[\"registry.terraform.io/hashicorp/aws\"]",
+   "instances":[{"attributes":{"id":"sg-056b65b187cd8ece3","vpc_id":"vpc-0f14b0f31c2dcaf94","description":"Bastion (SSM) - egress only","name":"tfdrift-lab-bastion"}}]}]}

--- a/demo/scan.sh
+++ b/demo/scan.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Act 3 — `tfdrift scan`: one-shot Terraform-state-vs-live-cloud reconcile.
+# Needs a valid AWS session (okta-aws-cli). Uses the lab bastion SG fixture so a
+# real security-group rule drift shows up.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${AWS_PROFILE:=draios-dev-developer}"; export AWS_PROFILE
+: "${AWS_REGION:=ap-northeast-1}"; export AWS_REGION
+sed "s#REPLACED_BY_SCAN_SH#$HERE/scan-state.tfstate#" "$HERE/scan-config.yaml" > "$HERE/.scan.run.yaml"
+"$HERE/.tfdrift" scan --config "$HERE/.scan.run.yaml" --output human

--- a/demo/state.tfstate
+++ b/demo/state.tfstate
@@ -1,0 +1,6 @@
+{"version":4,"terraform_version":"1.9.0","serial":1,"lineage":"demo","outputs":{},
+ "resources":[
+  {"mode":"managed","type":"aws_instance","name":"web",
+   "provider":"provider[\"registry.terraform.io/hashicorp/aws\"]",
+   "instances":[{"attributes":{"id":"i-0demoweb0000001","instance_type":"t3.micro","availability_zone":"ap-northeast-1a","tags":{"Name":"prod-web"}}}]}
+ ]}

--- a/demo/teardown.sh
+++ b/demo/teardown.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+for p in .backend.pid .ui.pid; do [ -f "$HERE/$p" ] && kill "$(cat "$HERE/$p")" 2>/dev/null && rm -f "$HERE/$p"; done
+rm -f "$HERE/.config.run.yaml" "$HERE/.scan.run.yaml"
+echo "demo stopped."

--- a/demo/trigger-realtime.sh
+++ b/demo/trigger-realtime.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Act 2 — real-time detection.
+# Simulates an out-of-band change: someone modifies a *Terraform-managed* prod
+# EC2 instance's type via the AWS Console. This POSTs the EXACT JSON that Falco
+# 0.43 emits over http_output for that CloudTrail event (ADR-006), so the demo
+# exercises the real receiver → parser → detector → UI path — no AWS needed.
+set -euo pipefail
+API="${TFDRIFT_API:-http://127.0.0.1:8080}"
+
+echo "▶ Scenario: alice@corp modifies prod EC2 instance-type via the AWS Console (outside Terraform)"
+curl -s -o /dev/null -w "  → tfdrift receiver: HTTP %{http_code}\n" \
+  -X POST "${API}/api/v1/falco/events" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "priority":"Warning",
+    "rule":"Terraform Managed Resource Modified",
+    "source":"aws_cloudtrail",
+    "time":"2026-08-10T09:30:00.000000000Z",
+    "output_fields":{
+      "ct.name":"ModifyInstanceAttribute",
+      "ct.region":"ap-northeast-1",
+      "ct.request":"{\"instanceId\":\"i-0demoweb0000001\",\"instanceType\":{\"value\":\"t3.2xlarge\"}}",
+      "ct.user":"alice@corp.example",
+      "ct.user.arn":"arn:aws:sts::230446364776:assumed-role/Admin/alice@corp.example",
+      "ct.user.accountid":"230446364776"
+    }
+  }'
+echo "  → Now watch the Dashboard: a drift card appears within ~5s (who=alice, what=ModifyInstanceAttribute)."


### PR DESCRIPTION
Turnkey, stage-reliable demo of the core value.

- **run.sh** — build + backend (Falco http transport) + UI, then return.
- **trigger-realtime.sh** (Act 2, no AWS) — POSTs the exact Falco 0.43 `http_output` JSON for an out-of-band change → drift card in the UI within ~5s (who/what/when), exercising receiver → parser → detector → broadcaster → UI. Deterministic; no AWS session / Falco container / S3 latency to flake on stage.
- **scan.sh** (Act 3, live AWS) — `tfdrift scan` reconcile showing the lab bastion SG ingress/egress rule drift.
- **README.md** — 3-act narration + backup-recording note + honest framing (#360).
- **teardown.sh** + `.gitignore` for runtime artifacts.

Both acts run-verified end-to-end. Demo fixtures are force-added (repo .gitignore excludes `*.tfstate` / `config.yaml`).
