### PR TITLE
demo: live-infra act — SG rule add → tfdrift scan detects

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -33,16 +33,22 @@ Within ~5s a drift card appears on the Dashboard:
 `aws_instance i-0demoweb0000001 — ModifyInstanceAttribute — alice@corp.example — medium`.
 (The feed auto-refreshes even if the tab isn't focused.)
 
-### Act 3 — one-shot reconcile (live AWS)
+### Act 3 — live drift on real infra (live AWS)
 ```bash
-bash demo/scan.sh
+bash demo/scan.sh          # baseline
+bash demo/drift-sg.sh      # add a Terraform-unmanaged ingress rule to the lab SG
+bash demo/scan.sh          # the new rule shows immediately as ingress drift
+bash demo/undrift-sg.sh    # cleanup
 ```
-Prints `Drift detected: … modified=1` with the lab bastion SG's ingress/egress
-rule drift (rules present in the cloud but not in state).
+`scan` queries the live security-group state directly, so an added rule is
+reported instantly — no CloudTrail delivery latency. (Real-time streaming to the
+UI over live CloudTrail lags minutes, so the live act uses `scan`, not the UI
+stream; Act 2 covers the real-time visual.)
 
 ### Teardown
 ```bash
-bash demo/teardown.sh
+bash demo/undrift-sg.sh   # revoke the demo SG rule
+bash demo/teardown.sh    # stop backend + UI
 ```
 
 ## Suggested 3-act narration (~5 min)

--- a/demo/drift-sg.sh
+++ b/demo/drift-sg.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Demo drift: add a Terraform-unmanaged ingress rule to the lab SG so `tfdrift
+# scan` reports it. Idempotent-ish (ignores "already exists").
+set -euo pipefail
+: "${AWS_PROFILE:=draios-dev-developer}"; export AWS_PROFILE
+: "${AWS_REGION:=ap-northeast-1}"; export AWS_REGION
+SG="${DEMO_SG:-sg-056b65b187cd8ece3}"
+PORT="${DEMO_PORT:-8443}"
+CIDR="${DEMO_CIDR:-203.0.113.7/32}"
+echo "▶ Adding out-of-band ingress rule to $SG: tcp/$PORT from $CIDR"
+aws ec2 authorize-security-group-ingress --group-id "$SG" \
+  --ip-permissions "IpProtocol=tcp,FromPort=$PORT,ToPort=$PORT,IpRanges=[{CidrIp=$CIDR,Description=demo-drift}]" \
+  --query 'SecurityGroupRules[0].SecurityGroupRuleId' --output text 2>&1 | tail -1 || true
+echo "  → now run: bash demo/scan.sh   (the new rule shows as ingress drift)"

--- a/demo/undrift-sg.sh
+++ b/demo/undrift-sg.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Cleanup: revoke the demo ingress rule.
+set -euo pipefail
+: "${AWS_PROFILE:=draios-dev-developer}"; export AWS_PROFILE
+: "${AWS_REGION:=ap-northeast-1}"; export AWS_REGION
+SG="${DEMO_SG:-sg-056b65b187cd8ece3}"
+PORT="${DEMO_PORT:-8443}"
+CIDR="${DEMO_CIDR:-203.0.113.7/32}"
+echo "▶ Revoking demo ingress rule tcp/$PORT from $CIDR on $SG"
+aws ec2 revoke-security-group-ingress --group-id "$SG" \
+  --ip-permissions "IpProtocol=tcp,FromPort=$PORT,ToPort=$PORT,IpRanges=[{CidrIp=$CIDR}]" 2>&1 | tail -1 || true
+echo "  done."


### PR DESCRIPTION
Reframes the live-AWS demo act around a real, instantly-detectable change: add a Terraform-unmanaged ingress rule to the lab SG, then `tfdrift scan` reports it immediately. `scan` reads live SG state directly (no CloudTrail latency), so it's the reliable live-infra act; real-time streaming to the UI (Act 2, driven) covers the real-time visual. Adds `drift-sg.sh` / `undrift-sg.sh` + updates Act 3.